### PR TITLE
(#7) add ComponentListener

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -319,6 +319,37 @@ fun main() {
 }
 ```
 
+There might be situations where you need to execute a specific code when a component gets added or removed from an entity.
+This can be done via `ComponentListener` in Fleks. 
+
+Here is an example of a listener that reacts on add/remove of a `Box2dComponent` and destroys the [body](https://github.com/libgdx/libgdx/wiki/Box2d#objectsbodies)
+when the component gets removed from an entity:
+
+```Kotlin
+data class Box2dComponent{
+    lateinit var body: Body
+}
+
+class Box2dComponentListener : ComponentListener<Box2dComponent> {
+    override fun onComponentAdded(entity: Entity, component: Box2dComponent) {
+        component.body = // body creation code omitted
+        component.body.userData = entity
+    }
+    
+    override fun onComponentRemoved(entity: Entity, component: Box2dComponent) {
+        component.body.world.destroyBody(body)
+        component.body.userData = null
+    }
+}
+
+fun main() {
+    val world = World {
+        // register the listener to the world
+        componentListener(Box2dComponentListener())
+    }
+}
+```
+
 ## Performance
 
 One important topic for me throughout the development of Fleks was performance. For that I compared Fleks with

--- a/src/main/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/component.kt
@@ -7,6 +7,15 @@ import kotlin.math.max
 import kotlin.reflect.KClass
 
 /**
+ * Interface of a component listener that gets notified when a component of a specific type
+ * gets added or removed from an [entity][Entity].
+ */
+interface ComponentListener<T> {
+    fun onComponentAdded(entity: Entity, component: T)
+    fun onComponentRemoved(entity: Entity, component: T)
+}
+
+/**
  * A class that is responsible to store components of a specific type for all [entities][Entity] in a [world][World].
  * Each component is assigned a unique [id] for fast access and to avoid lookups via a class which is slow.
  *
@@ -20,33 +29,43 @@ class ComponentMapper<T>(
     @PublishedApi
     internal val cstr: Constructor<T>
 ) {
+    @PublishedApi
+    internal val listeners = bag<ComponentListener<T>>(2)
+
     /**
      * Creates and returns a new component of the specific type for the given [entity] and applies the [configuration].
      * If the [entity] already has a component of that type then no new instance will be created.
+     * Notifies any registered [ComponentListener].
      */
     @PublishedApi
     internal inline fun addInternal(entity: Entity, configuration: T.() -> Unit = {}): T {
         if (entity.id >= components.size) {
             components = components.copyOf(max(components.size * 2, entity.id + 1))
         }
-        var cmp = components[entity.id]
+        val cmp = components[entity.id]
         return if (cmp == null) {
-            cmp = cstr.newInstance().apply(configuration)
-            components[entity.id] = cmp
-            cmp
+            val newCmp = cstr.newInstance().apply(configuration)
+            components[entity.id] = newCmp
+            listeners.forEach { it.onComponentAdded(entity, newCmp) }
+            newCmp
         } else {
-            cmp.apply(configuration)
+            val existingCmp = cmp.apply(configuration)
+            listeners.forEach { it.onComponentAdded(entity, existingCmp) }
+            existingCmp
         }
     }
 
-
     /**
      * Removes a component of the specific type from the given [entity].
+     * Notifies any registered [ComponentListener].
      *
      * @throws [ArrayIndexOutOfBoundsException] if the id of the [entity] exceeds the components' capacity.
      */
     @PublishedApi
     internal fun removeInternal(entity: Entity) {
+        components[entity.id]?.let { cmp ->
+            listeners.forEach { it.onComponentRemoved(entity, cmp) }
+        }
         components[entity.id] = null
     }
 
@@ -63,6 +82,29 @@ class ComponentMapper<T>(
      * Returns true if and only if the given [entity] has a component of the specific type.
      */
     operator fun contains(entity: Entity): Boolean = components.size > entity.id && components[entity.id] != null
+
+    /**
+     * Adds the given [listener] to the list of [ComponentListener].
+     */
+    fun addComponentListener(listener: ComponentListener<T>) = listeners.add(listener)
+
+    /**
+     * Adds the given [listener] to the list of [ComponentListener]. This function is only used internally
+     * to add listeners through the [WorldConfiguration].
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun addComponentListenerInternal(listener: ComponentListener<*>) =
+        addComponentListener(listener as ComponentListener<T>)
+
+    /**
+     * Removes the given [listener] from the list of [ComponentListener].
+     */
+    fun removeComponentListener(listener: ComponentListener<T>) = listeners.removeValue(listener)
+
+    /**
+     * Returns true if and only if the given [listener] is part of the list of [ComponentListener].
+     */
+    operator fun contains(listener: ComponentListener<T>) = listener in listeners
 
     override fun toString(): String {
         return "ComponentMapper(id=$id, component=${cstr.name})"

--- a/src/main/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/component.kt
@@ -49,6 +49,11 @@ class ComponentMapper<T>(
             listeners.forEach { it.onComponentAdded(entity, newCmp) }
             newCmp
         } else {
+            // component already added -> reuse it and do not create a new instance.
+            // Call onComponentRemoved first in case users do something special in onComponentAdded.
+            // Otherwise, onComponentAdded will be executed twice on a single component without executing onComponentRemoved
+            // which is not correct.
+            listeners.forEach { it.onComponentRemoved(entity, cmp) }
             val existingCmp = cmp.apply(configuration)
             listeners.forEach { it.onComponentAdded(entity, existingCmp) }
             existingCmp

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -246,6 +246,7 @@ class EntityService(
      * Removes the given [listener] from the list of [EntityListener].
      */
     fun removeEntityListener(listener: EntityListener) = listeners.removeValue(listener)
+
     /**
      * Returns true if and only if the given [listener] is part of the list of [EntityListener].
      */

--- a/src/main/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/exception.kt
@@ -21,3 +21,6 @@ class FleksMissingNoArgsComponentConstructorException(component: KClass<*>) :
 
 class FleksNoSuchComponentException(entity: Entity, component: String) :
     FleksException("Entity $entity has no component of type $component")
+
+class FleksComponentListenerAlreadyAddedException(listener: ComponentListener<*>) :
+    FleksException("ComponentListener ${listener.javaClass.simpleName} is already part of the ${WorldConfiguration::class.simpleName}")

--- a/src/test/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -17,17 +17,20 @@ private class ComponentTestComponentListener : ComponentListener<ComponentTestCo
     var numRemoveCalls = 0
     lateinit var cmpCalled: ComponentTestComponent
     var entityCalled = Entity(-1)
+    var lastCall = ""
 
     override fun onComponentAdded(entity: Entity, component: ComponentTestComponent) {
         numAddCalls++
         cmpCalled = component
         entityCalled = entity
+        lastCall = "add"
     }
 
     override fun onComponentRemoved(entity: Entity, component: ComponentTestComponent) {
         numRemoveCalls++
         cmpCalled = component
         entityCalled = entity
+        lastCall = "remove"
     }
 }
 
@@ -204,6 +207,26 @@ internal class ComponentTest {
             { assertEquals(0, listener.numRemoveCalls) },
             { assertEquals(expectedEntity, listener.entityCalled) },
             { assertEquals(expectedCmp, listener.cmpCalled) }
+        )
+    }
+
+    @Test
+    fun `add component with ComponentListener when component already present`() {
+        val cmpService = ComponentService()
+        val mapper = cmpService.mapper<ComponentTestComponent>()
+        val expectedEntity = Entity(1)
+        mapper.addInternal(expectedEntity)
+        val listener = ComponentTestComponentListener()
+        mapper.addComponentListener(listener)
+
+        val expectedCmp = mapper.addInternal(expectedEntity)
+
+        assertAll(
+            { assertEquals(1, listener.numAddCalls) },
+            { assertEquals(1, listener.numRemoveCalls) },
+            { assertEquals(expectedEntity, listener.entityCalled) },
+            { assertEquals(expectedCmp, listener.cmpCalled) },
+            { assertEquals("add", listener.lastCall) }
         )
     }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -37,6 +37,11 @@ private class WorldTestIteratingSystem(
     override fun onTickEntity(entity: Entity) = Unit
 }
 
+private class WorldTestComponentListener : ComponentListener<WorldTestComponent> {
+    override fun onComponentAdded(entity: Entity, component: WorldTestComponent) = Unit
+    override fun onComponentRemoved(entity: Entity, component: WorldTestComponent) = Unit
+}
+
 internal class WorldTest {
     @Test
     fun `create empty world for 32 entities`() {
@@ -174,5 +179,26 @@ internal class WorldTest {
             { assertTrue(w.system<WorldTestIntervalSystem>().disposed) },
             { assertEquals(0, w.numEntities) }
         )
+    }
+
+    @Test
+    fun `create world with ComponentListener`() {
+        val listener = WorldTestComponentListener()
+        val w = World {
+            componentListener(listener)
+        }
+
+        assertTrue { listener in w.componentService.mapper<WorldTestComponent>() }
+    }
+
+    @Test
+    fun `cannot add same ComponentListener twice`() {
+        assertThrows<FleksComponentListenerAlreadyAddedException> {
+            val listener = WorldTestComponentListener()
+            World {
+                componentListener(listener)
+                componentListener(listener)
+            }
+        }
     }
 }


### PR DESCRIPTION
PR for #7 

First, I wanted to add a new function annotation so that you can write a function in any system an annotate it with `@ComponentAdded` or `@ComponentRemoved` and it will then automatically be called by the specific `ComponentMapper`.

However, doing that requires again reflection calls to invoke the method which is ~3-4x times slower than a normal function call.

I then read a few different approaches and went for the `ComponentListener` approach which can be defined with the `WorldConfiguration`.

We could actually allow that at any point in time but in my opinion this setup is known from the beginning and does not change during runtime. That's why I put it into the configuration area.

We could create the listeners via dependency injection like we do it for systems but for now I did not went that route because I am not sure if a `ComponentListener` ever needs arguments. This can be changed if needed.