### PR TITLE
(#9) access entity within EntityCreateCfg

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -316,6 +316,13 @@ fun main() {
         add<Position> { x = 5f }
         add<Sprite>()
     }
+    
+    // if needed, you can already access the new entity within the entity{} block
+    val entity2 = world.entity { e -> 
+        // e is the same as entity2
+        // this can be useful in some cases where you want to set the entity as
+        // custom userData on certain third-party library objects directly
+    }
 }
 ```
 

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -154,7 +154,7 @@ class EntityService(
      * If there are [recycledEntities] then they will be preferred over creating new entities.
      * Notifies any registered [EntityListener].
      */
-    inline fun create(configuration: EntityCreateCfg.() -> Unit): Entity {
+    inline fun create(configuration: EntityCreateCfg.(Entity) -> Unit): Entity {
         val newEntity = if (recycledEntities.isEmpty()) {
             Entity(nextId++)
         } else {
@@ -168,7 +168,7 @@ class EntityService(
         createCfg.run {
             this.entity = newEntity
             this.cmpMask = cmpMask
-            configuration()
+            configuration(this.entity)
         }
         listeners.forEach { it.onEntityCfgChanged(newEntity, cmpMask) }
 

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -113,7 +113,7 @@ class World(
     /**
      * Adds a new [entity][Entity] to the world using the given [configuration][EntityCreateCfg].
      */
-    inline fun entity(configuration: EntityCreateCfg.() -> Unit = {}): Entity {
+    inline fun entity(configuration: EntityCreateCfg.(Entity) -> Unit = {}): Entity {
         return entityService.create(configuration)
     }
 

--- a/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
@@ -64,15 +64,20 @@ internal class EntityTest {
         val entityService = EntityService(32, cmpService)
         val listener = EntityTestListener()
         entityService.addEntityListener(listener)
+        var processedEntity = Entity(-1)
 
-        val expectedEntity = entityService.create { add<EntityTestComponent>() }
+        val expectedEntity = entityService.create { entity ->
+            add<EntityTestComponent>()
+            processedEntity = entity
+        }
         val mapper = cmpService.mapper<EntityTestComponent>()
 
         assertAll(
             { assertEquals(1, listener.numCalls) },
             { assertEquals(expectedEntity, listener.entityReceived) },
             { assertTrue(listener.cmpMaskReceived[0]) },
-            { assertEquals(0f, mapper[listener.entityReceived].x) }
+            { assertEquals(0f, mapper[listener.entityReceived].x) },
+            { assertEquals(expectedEntity, processedEntity) }
         )
     }
 


### PR DESCRIPTION
PR for #9 

Wanted to make something like:

```Kotlin
var entity : Entity(-1)
  internal set
```

But this is not possible because `@PublishedAPI` cannot be set on setters.  Also, making it public is not correct because then a user could change it which is not intentional.
Therefore, I just added `Entity` as an argument for the create configuration of an entity to allow something like:

```Kotlin
world.entity{ e ->
  // e is the newly created entity and can now be directly accessed within the cfg block
}
```