### PR TITLE
(#11) report unused injectables

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/exception.kt
@@ -24,3 +24,6 @@ class FleksNoSuchComponentException(entity: Entity, component: String) :
 
 class FleksComponentListenerAlreadyAddedException(listener: ComponentListener<*>) :
     FleksException("ComponentListener ${listener.javaClass.simpleName} is already part of the ${WorldConfiguration::class.simpleName}")
+
+class FleksUnusedInjectablesException(unused: List<KClass<*>>) :
+    FleksException("There are unused injectables of following types: ${unused.map { it.simpleName }}")

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -3,6 +3,12 @@ package com.github.quillraven.fleks
 import kotlin.reflect.KClass
 
 /**
+ * Wrapper class for injectables of the [WorldConfiguration].
+ * It is used in the [SystemService] to find out any unused injectables.
+ */
+data class Injectable(val injObj: Any, var used: Boolean = false)
+
+/**
  * A configuration for an entity [world][World] to define the initial maximum entity capacity,
  * the systems of the [world][World] and the systems' dependencies to be injected.
  * Additionally, you can define [ComponentListener] to define custom logic when a specific component is
@@ -20,7 +26,7 @@ class WorldConfiguration {
     internal val systemTypes = mutableListOf<KClass<out IntervalSystem>>()
 
     @PublishedApi
-    internal val injectables = mutableMapOf<KClass<*>, Any>()
+    internal val injectables = mutableMapOf<KClass<*>, Injectable>()
 
     @PublishedApi
     internal val cmpListeners = mutableMapOf<KClass<*>, MutableList<ComponentListener<out Any>>>()
@@ -49,7 +55,7 @@ class WorldConfiguration {
         if (injectType in injectables) {
             throw FleksInjectableAlreadyAddedException(injectType)
         }
-        injectables[injectType] = dependency
+        injectables[injectType] = Injectable(dependency)
     }
 
     /**

--- a/src/test/kotlin/com/github/quillraven/fleks/SystemTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/SystemTest.kt
@@ -225,7 +225,7 @@ internal class SystemTest {
         val service = SystemService(
             expectedWorld,
             listOf(SystemTestIteratingSystemInjectable::class),
-            mapOf(String::class to "42")
+            mapOf(String::class to Injectable("42"))
         )
 
         val actualSystem = service.system<SystemTestIteratingSystemInjectable>()
@@ -254,6 +254,17 @@ internal class SystemTest {
                 World.EMPTY_WORLD,
                 listOf(SystemTestIteratingSystemInjectable::class),
                 emptyMap()
+            )
+        }
+    }
+
+    @Test
+    fun `throw exception when there are unused injectables`() {
+        assertThrows<FleksUnusedInjectablesException> {
+            SystemService(
+                World.EMPTY_WORLD,
+                listOf(SystemTestIntervalSystemEachFrame::class),
+                mapOf(String::class to Injectable("42"))
             )
         }
     }


### PR DESCRIPTION
PR for #11 

I did not want to introduce a logging dependency just for that and also `println` did not seem correct.
In my opinion this is something that should not happen and the user set something up incorrectly which leads to maybe strange behavior.

That's why I went for a new exception to report any unused injectables.