### PR TITLE
(#25) fix behavior when the same entity gets removed twice

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,20 +53,20 @@ To use Fleks add it as a dependency to your project:
 <dependency>
   <groupId>io.github.quillraven.fleks</groupId>
   <artifactId>Fleks</artifactId>
-  <version>1.0-RC1</version>
+  <version>1.0-RC2</version>
 </dependency>
 ```
 
 #### Gradle (Groovy)
 
 ```kotlin
-implementation 'io.github.quillraven.fleks:Fleks:1.0-RC1'
+implementation 'io.github.quillraven.fleks:Fleks:1.0-RC2'
 ```
 
 #### Gradle (Kotlin)
 
 ```kotlin
-implementation("io.github.quillraven.fleks:Fleks:1.0-RC1")
+implementation("io.github.quillraven.fleks:Fleks:1.0-RC2")
 ```
 
 ## Current API and usage

--- a/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
@@ -241,4 +241,21 @@ internal class EntityTest {
 
         assertFalse(listener in entityService)
     }
+
+    @Test
+    fun `remove entity twice`() {
+        val cmpService = ComponentService()
+        val entityService = EntityService(32, cmpService)
+        val entity = entityService.create { }
+        val listener = EntityTestListener()
+        entityService.addEntityListener(listener)
+
+        entityService.remove(entity)
+        entityService.remove(entity)
+
+        assertAll(
+            { assertEquals(1, entityService.recycledEntities.size) },
+            { assertEquals(1, listener.numCalls) }
+        )
+    }
 }


### PR DESCRIPTION
PR for #25 

I introduced a new `BitArray` in the `EntityService` to remember when an entity is already removed. Run the benchmarks again to see if there is any performance impact but it doesn't seem like it.

The BitArray should be in sync with the recycledEntities deque. The position is set to 1 if the entity is part of the recycledEntities. Otherwise, it will be zero.