### PR TITLE
(#20) add onInit function for systems

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -239,7 +239,23 @@ fun main() {
 }
 ```
 
-----
+Some systems might need an initialization code that requires the `world`. Unfortunately, it is not possible to
+get access to the world in a normal `init` block. The field is not initialized at that time. However, there is
+of course a solution. In case you need the world for your initialization logic you can use the `onInit` function of a system like this:
+
+```Kotlin
+private class PlayerSpawnSystem() : IntervalSystem() {
+    override fun onInit() {
+        // spawn player when the system gets created
+        // Note: access to the world field works inside this method
+        world.entity {
+            // ...
+        }
+    }
+
+    // ...
+}
+```
 
 Sometimes it might be necessary to sort entities before iterating over them like e.g. in a `RenderSystem` that needs to
 render entities by their y or z-coordinate. In Fleks this can be achieved by passing an `EntityComparator` to

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -118,8 +118,4 @@ data class Family(
             entities.clear(entity.id)
         }
     }
-
-    companion object {
-        internal val EMPTY_FAMILY = Family()
-    }
 }

--- a/src/main/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/system.kt
@@ -41,7 +41,8 @@ abstract class IntervalSystem(
      * Returns the [world][World] to which this system belongs.
      * This reference gets updated by the [SystemService] when the system gets created via reflection.
      */
-    val world: World = World.EMPTY_WORLD
+    lateinit var world: World
+        internal set
 
     private var accumulator: Float = 0.0f
 
@@ -54,6 +55,12 @@ abstract class IntervalSystem(
      */
     val deltaTime: Float
         get() = if (interval is Fixed) interval.step else world.deltaTime
+
+    /**
+     * Optional function for any initialization logic that requires access to the [world].
+     * This is necessary because the normal init block does not have an initialized [world] yet.
+     */
+    open fun onInit() = Unit
 
     /**
      * Updates the system according to its [interval]. This function gets called from [World.update] when
@@ -136,14 +143,15 @@ abstract class IteratingSystem(
      * Returns the [family][Family] of this system.
      * This reference gets updated by the [SystemService] when the system gets created via reflection.
      */
-    private val family: Family = Family.EMPTY_FAMILY
+    private lateinit var family: Family
 
     /**
      * Returns the [entityService][EntityService] of this system.
      * This reference gets updated by the [SystemService] when the system gets created via reflection.
      */
     @PublishedApi
-    internal val entityService: EntityService = world.entityService
+    internal lateinit var entityService: EntityService
+        private set
 
     /**
      * Flag that defines if sorting of [entities][Entity] will be performed the next time [onTick] is called.
@@ -279,7 +287,7 @@ class SystemService(
                 eServiceField.set(newSystem, entityService)
             }
 
-            newSystem
+            newSystem.apply { onInit() }
         }
 
         // verify that there are no unused injectables

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -173,8 +173,4 @@ class World(
         entityService.removeAll()
         systemService.dispose()
     }
-
-    companion object {
-        internal val EMPTY_WORLD = World { entityCapacity = 0 }
-    }
 }


### PR DESCRIPTION
PR for #20 

Added `onInit` function and also replaced some val with lateinit var because that way the user gets an exception if he tries to access the world in an `init` block.

I compared the performance of lateinit var vs val and it seems to have no impact. Actually, on my notebook it seems to be slightly faster for whatever reason.