### PR TITLE
Fix unit tests and update sources

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/component.kt
@@ -16,7 +16,7 @@ interface ComponentListener<T> {
 /**
  * A class that is responsible to store components of a specific type for all [entities][Entity] in a [world][World].
  * Each component is assigned a unique [id] for fast access and to avoid lookups via a class which is slow.
- * A component of the [components] array at index X belongs to the [Entity] of id X.
+ * Hint: A component at index [id] in the [components] array belongs to [Entity] with the same [id].
  *
  * Refer to [ComponentService] for more details.
  */

--- a/src/main/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/exception.kt
@@ -26,14 +26,14 @@ class FleksInjectableAlreadyAddedException(type: String) :
 class FleksInjectableTypeHasNoName(type: KClass<*>) :
     FleksException("Injectable '$type' does not have simpleName in its class type.")
 
-class FleksSystemInjectException(injectType: String) :
+class FleksSystemDependencyInjectException(injectType: String) :
     FleksException("Injection object of type '$injectType' cannot be found. Did you add all necessary injectables?")
+
+class FleksSystemComponentInjectException(injectType: String) :
+    FleksException("Component mapper for type '$injectType' cannot be found. Did you add that component to the world configuration?")
 
 class FleksNoSuchEntityComponentException(entity: Entity, component: String) :
     FleksException("Entity '$entity' has no component of type '$component'.")
-
-class FleksComponentListenerAlreadyAddedException(listener: String) :
-    FleksException("ComponentListener '$listener' is already part of the '${WorldConfiguration::class.simpleName}'.")
 
 class FleksUnusedInjectablesException(unused: List<KClass<*>>) :
     FleksException("There are unused injectables of following types: ${unused.map { it.simpleName }}")

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -6,21 +6,6 @@ import com.github.quillraven.fleks.collection.IntBag
 import kotlin.reflect.KClass
 
 /**
- * [Entities][Entity] must have all [components] specified to be part of the [family][Family].
- */
-class AllOf(val components: Array<KClass<*>>)
-
-/**
- * [Entities][Entity] must not have any [components] specified to be part of the [family][Family].
- */
-class NoneOf(val components: Array<KClass<*>>)
-
-/**
- * [Entities][Entity] must have at least one of the [components] specified to be part of the [family][Family].
- */
-class AnyOf(val components: Array<KClass<*>>)
-
-/**
  * A family of [entities][Entity]. It stores [entities][Entity] that have a specific configuration of components.
  * A configuration is defined via the three [IteratingSystem] properties "allOf", "noneOf" and "anyOf".
  * Each component is assigned to a unique index. That index is set in the [allOf], [noneOf] or [anyOf][] [BitArray].


### PR DESCRIPTION
This commit fixes the unit test run. It updates the unit tests to the
changed API which was needed to remove the dependency to java
annotations, etc. Some minor test cases are not needed anymore because
annotations are not used to create objects. Instead objects are created
using constructor functions. That makes some test cases obsolete. Also
some test cases were changed to check the adapted exeption objects.

Some minor changes in the Fleks sources were done due to cleanup code
which was before used by annotations. Also the registering of component
listeners was made more robust by defining the expected type T. That was
found while getting the unit tests running :)