### PR TITLE
fix issue that families are not updated correctly during system creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,12 @@ publishing {
     }
 }
 
+// only sign if version is not a SNAPSHOT release.
+// this makes it easier to publish to mavenLocal and test the packed version.
+tasks.withType<Sign>().configureEach {
+    onlyIf { !project.version.toString().endsWith("SNAPSHOT") }
+}
+
 signing {
     useInMemoryPgpKeys(System.getenv("SIGNING_KEY"), System.getenv("SIGNING_PASSWORD"))
     sign(publishing.publications[publicationName])

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -199,6 +199,13 @@ class EntityService(
     }
 
     /**
+     * Notifies all registered [EntityListener].
+     */
+    internal fun notifyAll() {
+        forEach { e -> listeners.forEach { l -> l.onEntityCfgChanged(e, cmpMasks[e.id]) } }
+    }
+
+    /**
      * Updates an [entity] with the given [configuration].
      * Notifies any registered [EntityListener].
      */

--- a/src/main/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/system.kt
@@ -33,7 +33,7 @@ data class Fixed(val step: Float) : Interval
  */
 abstract class IntervalSystem(
     val interval: Interval = EachFrame,
-    var enabled: Boolean = true
+    var enabled: Boolean = true,
 ) {
     /**
      * Returns the [world][World] to which this system belongs.
@@ -255,6 +255,16 @@ class SystemService(
             }
 
             newSystem
+        }
+
+        // Families are created above together with its system. This can have the side effect that they are
+        // not updated correctly if entities get created in a system's init block because they are not existing
+        // at the time of entity creation.
+        // To fix this we notify them manually for each entity that got created that way.
+        allFamilies.forEach { family ->
+            entityService.forEach { entity ->
+                family.onEntityCfgChanged(entity, entityService.cmpMasks[entity.id])
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/system.kt
@@ -2,7 +2,6 @@ package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.BitArray
 import com.github.quillraven.fleks.collection.EntityComparator
-import java.lang.reflect.Field
 import kotlin.reflect.KClass
 
 /**
@@ -133,7 +132,7 @@ abstract class IteratingSystem(
      * Returns the [family][Family] of this system.
      * This reference gets updated by the [SystemService] when the system gets created via reflection.
      */
-    private lateinit var family: Family
+    internal lateinit var family: Family
 
     /**
      * Returns the [entityService][EntityService] of this system.
@@ -167,7 +166,7 @@ abstract class IteratingSystem(
      * a FleksNoSuchComponentException. To avoid that you could check if an entity really has the component
      * before accessing it but that is redundant in context of a family.
      *
-     * To avoid these kinds of problems, entity removals are delayed until the end of the iteration. This also means
+     * To avoid these kinds of issues, entity removals are delayed until the end of the iteration. This also means
      * that a removed entity of this family will still be part of the [onTickEntity] for the current iteration.
      */
     override fun onTick() {
@@ -245,27 +244,20 @@ class SystemService(
             val sysType = systemTypes[sysIdx]
             val newSystem = newInstance(sysType, cmpService, injectables)
 
-            if (IteratingSystem::class.java.isAssignableFrom(sysType.java)) {
+            if (newSystem is IteratingSystem) {
                 // set family reference of newly created iterating system
                 @Suppress("UNCHECKED_CAST")
-                val family = family(sysType as KClass<out IteratingSystem>, entityService, cmpService, allFamilies)
-                val famField = field(newSystem, "family")
-                famField.isAccessible = true
-                famField.set(newSystem, family)
+                newSystem.family = family(sysType as KClass<out IteratingSystem>, entityService, cmpService, allFamilies)
             }
 
             newSystem
         }
 
         // Families are created above together with its system. This can have the side effect that they are
-        // not updated correctly if entities get created in a system's init block because they are not existing
-        // at the time of entity creation.
-        // To fix this we notify them manually for each entity that got created that way.
-        allFamilies.forEach { family ->
-            entityService.forEach { entity ->
-                family.onEntityCfgChanged(entity, entityService.cmpMasks[entity.id])
-            }
-        }
+        // not updated correctly if entities get created in a system's init block because the family might not exist
+        // at that time.
+        // Therefore, we need to notify them one time after all families are available to update them correctly.
+        entityService.notifyAll()
     }
 
     /**
@@ -333,29 +325,6 @@ class SystemService(
             allFamilies.add(family)
         }
         return family
-    }
-
-    /**
-     * Returns a [Field] of name [fieldName] of the given [system].
-     *
-     * @throws [FleksSystemCreationException] if the [system] does not have a [Field] of name [fieldName].
-     */
-    private fun field(system: IntervalSystem, fieldName: String): Field {
-        var sysClass: Class<*> = system::class.java
-        var classField: Field? = null
-        while (classField == null) {
-            try {
-                classField = sysClass.getDeclaredField(fieldName)
-            } catch (e: NoSuchFieldException) {
-                val supC = sysClass.superclass ?: throw FleksSystemCreationException(
-                    system::class,
-                    "No '$fieldName' field found"
-                )
-                sysClass = supC
-            }
-
-        }
-        return classField
     }
 
     /**


### PR DESCRIPTION
Fix for #40 
this is also relevant for the upcoming KMP version

----

A different solution would be to first create the families in the `SystemService` and afterwards the systems. However, this requires to iterate over the `systemTypes` parameter twice and also find the family again for each system in the `allFamilies` list.

I did not like that a lot that's why I added a separate iteration over all families and entities afterwards. I guess entity creation in a system init block is an exceptional case so the iteration count should be minimal.