### PR TITLE
make world available as a dependency

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -429,7 +429,8 @@ fun main() {
 
 There might be situations where you need to execute a specific code when a component gets added or removed from an entity.
 This can be done via `ComponentListener` in Fleks. They are created in a similar way like systems meaning that they are created
-by Fleks using dependency injection.
+by Fleks using dependency injection. The `world` of a `ComponentListener`
+is automatically available as a dependency like any `ComponentMapper`.
 
 Here is an example of a listener that reacts on add/remove of a `Box2dComponent` and destroys the [body](https://github.com/libgdx/libgdx/wiki/Box2d#objectsbodies)
 when the component gets removed from an entity:

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -141,6 +141,8 @@ class World(
         // created inside the SystemService below.
         entityService = EntityService(worldCfg.entityCapacity, componentService)
         val injectables = worldCfg.injectables
+        // add the world as a used dependency in case any system or ComponentListener needs it
+        injectables[World::class.qualifiedName!!] = Injectable(this, true)
         // set a Fleks internal global reference to the current world that
         // gets created. This is used to correctly initialize the world
         // reference of any created system in the SystemService below.

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -56,7 +56,9 @@ private class WorldTestNamedDependencySystem(
     override fun onTick() = Unit
 }
 
-private class WorldTestComponentListener : ComponentListener<WorldTestComponent> {
+private class WorldTestComponentListener(
+    val world: World
+) : ComponentListener<WorldTestComponent> {
     override fun onComponentAdded(entity: Entity, component: WorldTestComponent) = Unit
     override fun onComponentRemoved(entity: Entity, component: WorldTestComponent) = Unit
 }
@@ -223,8 +225,12 @@ internal class WorldTest {
         val w = World {
             componentListener<WorldTestComponentListener>()
         }
+        val actualListeners = w.componentService.mapper<WorldTestComponent>().listeners
 
-        assertEquals(1, w.componentService.mapper<WorldTestComponent>().listeners.size)
+        assertAll(
+            { assertEquals(1, actualListeners.size) },
+            { assertEquals(w, (actualListeners[0] as WorldTestComponentListener).world) }
+        )
     }
 
     @Test


### PR DESCRIPTION
makes the world a dependency for the DI mechanism. For system's this is not useful as they anyway hold a reference to the world but for ComponentListener it is useful in some cases