### PR TITLE
add world systems getter

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -134,6 +134,12 @@ class World(
     val capacity: Int
         get() = entityService.capacity
 
+    /**
+     * Returns the world's systems.
+     */
+    val systems: Array<IntervalSystem>
+        get() = systemService.systems
+
     init {
         val worldCfg = WorldConfiguration().apply(cfg)
         // It is important to create the EntityService before the SystemService

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -80,6 +80,13 @@ internal class WorldTest {
     }
 
     @Test
+    fun `get world systems`() {
+        val w = World { system<WorldTestIntervalSystem>() }
+
+        assertEquals(w.systemService.systems, w.systems)
+    }
+
+    @Test
     fun `create empty world with 1 injectable args IteratingSystem`() {
         val w = World {
             system<WorldTestIteratingSystem>()


### PR DESCRIPTION
This PR adds a getter for the world's systems. This is useful if a user wants to iterate over all systems an do something.

E.g. I use it to iterate over all systems that implement a certain interface and register them once as a special listener. To not do that in every single constructor of a system, which I tend to forget, I can do that via one simple loop.