### PR TITLE
add configureEntity to world

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -173,6 +173,13 @@ class World(
     }
 
     /**
+     * Updates an [entity] using the given [configuration] to add and remove components.
+     */
+    inline fun configureEntity(entity: Entity, configuration: EntityUpdateCfg.(Entity) -> Unit) {
+        entityService.configureEntity(entity, configuration)
+    }
+
+    /**
      * Removes the given [entity] from the world. The [entity] will be recycled and reused for
      * future calls to [World.entity].
      */

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -29,13 +29,16 @@ private class WorldTestIteratingSystem(
     val mapper: ComponentMapper<WorldTestComponent>
 ) : IteratingSystem() {
     var numCalls = 0
+    var numCallsEntity = 0
 
     override fun onTick() {
         ++numCalls
         super.onTick()
     }
 
-    override fun onTickEntity(entity: Entity) = Unit
+    override fun onTickEntity(entity: Entity) {
+        ++numCallsEntity
+    }
 }
 
 @AllOf([WorldTestComponent::class])
@@ -295,5 +298,20 @@ internal class WorldTest {
             { assertEquals(w2, w2.system<WorldTestInitSystem>().world) },
             { assertEquals(1, w2.numEntities) },
         )
+    }
+
+    @Test
+    fun `configure entity after creation`() {
+        val w = World {
+            inject("test")
+            system<WorldTestIteratingSystem>()
+        }
+        val e = w.entity()
+        val mapper: ComponentMapper<WorldTestComponent> = w.mapper()
+
+        w.configureEntity(e) { mapper.add(it) }
+        w.update(0f)
+
+        assertEquals(1, w.system<WorldTestIteratingSystem>().numCallsEntity)
     }
 }


### PR DESCRIPTION
As someone suggested on YouTube it would be good to be able to configure an entity outside of a system. I think this was an oversight by me when I introduced the `mapper` function to the `world`. I forgot that adding/removing components is not available that way because of the way I optimize the component configuration change for performance reasons.

Anyway, this PR makes it now possible as seen in the test:

```kotlin
@Test
    fun `configure entity after creation`() {
        val w = World {
            inject("test")
            system<WorldTestIteratingSystem>()
        }
        val e = w.entity()
        val mapper: ComponentMapper<WorldTestComponent> = w.mapper()

        w.configureEntity(e) { mapper.add(it) }
        w.update(0f)

        assertEquals(1, w.system<WorldTestIteratingSystem>().numCallsEntity)
    }
```