### PR TITLE
add support to create families via the world

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -393,12 +393,55 @@ The world's `forEach` function allows you to iterate over all active entities:
     val e3 = world.entity()
     world.remove(e2)
 
-    // this will iterate over entities e1 and e3
+    // this will iterate over entities e1..e3
     world.forEach { entity ->
         // do something with the entity
     }
 }
 ```
+
+In case you need to iterate over entities with a specific component configuration
+that is not part of a system then this is possible via the `family` function
+of a `world`. 
+A `family` keeps track of entities with a specific config and allows sorting
+and iteration over these entities. The following example shows how to
+get a `family` for entities with a MoveComponent but without a DeadComponent:
+
+```kotlin
+fun main() {
+    val world = World {}
+    val e1 = w.entity { 
+        add<MoveComponent> { speed = 70f } 
+    }
+    val e2 = w.entity { 
+        add<MoveComponent> { speed = 50f }
+        add<DeadComponent>()
+    }
+    val e3 = w.entity { 
+        add<MoveComponent> { speed = 30f } 
+    }
+
+    // get family for entities with a MoveComponent
+    // and without a DeadComponent
+    val family = world.family(
+        allOf = arrayOf(MoveComponent::class),
+        noneOf = arrayOf(DeadComponent::class),
+    )
+
+    // you can sort entities of a family
+    val moves = world.mapper<MoveComponent>()
+    family.sort(compareEntity { entity1, entity2 -> moves[entity1].speed.compareTo(moves[entity2].speed) })
+    
+    // And you can iterate over entities of a family.
+    // In this example it will iterate in following order:
+    // 1) e3
+    // 2) e1
+    family.forEach { entity ->
+        // do something with the entity
+    }
+}
+```
+
 
 ### Entity and Components
 

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -199,13 +199,6 @@ class EntityService(
     }
 
     /**
-     * Notifies all registered [EntityListener].
-     */
-    internal fun notifyAll() {
-        forEach { e -> listeners.forEach { l -> l.onEntityCfgChanged(e, cmpMasks[e.id]) } }
-    }
-
-    /**
      * Updates an [entity] with the given [configuration].
      * Notifies any registered [EntityListener].
      */

--- a/src/main/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/exception.kt
@@ -33,3 +33,14 @@ class FleksUnusedInjectablesException(unused: List<KClass<*>>) :
 
 class FleksReflectionException(type: KClass<*>, details: String) :
     FleksException("Cannot create ${type.simpleName}.\nDetails: $details")
+
+class FleksFamilyException(
+    allOf: List<ComponentMapper<*>>?,
+    noneOf: List<ComponentMapper<*>>?,
+    anyOf: List<ComponentMapper<*>>?,
+) : FleksException(
+    """Family must have at least one of allOf, noneOf or anyOf.
+        |allOf: $allOf
+        |noneOf: $noneOf
+        |anyOf: $anyOf""".trimMargin()
+)

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -58,6 +58,12 @@ data class Family(
     private val entities = BitArray(1)
 
     /**
+     * Returns the number of [entities][Entity] that belong to this family.
+     */
+    val numEntities: Int
+        get() = entities.length()
+
+    /**
      * Flag to indicate if there are changes in the [entities]. If it is true then the [entitiesBag] should get
      * updated via a call to [updateActiveEntities].
      *
@@ -117,5 +123,38 @@ data class Family(
             isDirty = true
             entities.clear(entity.id)
         }
+    }
+}
+
+/**
+ * A [family][Family] of [entities][Entity] created without an [IteratingSystem].
+ * It stores [entities][Entity] that have a specific configuration of components.
+ */
+class WorldFamily(
+    internal val family: Family,
+    private val entityService: EntityService,
+) {
+    /**
+     * Sorts the [entities][Entity] of this family by the given [comparator].
+     */
+    fun sort(comparator: EntityComparator) {
+        if (family.isDirty) {
+            family.updateActiveEntities()
+        }
+
+        family.sort(comparator)
+    }
+
+    /**
+     * Performs the given [action] on each [entity][Entity] of the [family].
+     */
+    fun forEach(action: (Entity) -> Unit) {
+        if (family.isDirty) {
+            family.updateActiveEntities()
+        }
+
+        entityService.delayRemoval = true
+        family.forEach { action(it) }
+        entityService.cleanupDelays()
     }
 }

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -1,5 +1,6 @@
 package com.github.quillraven.fleks
 
+import com.github.quillraven.fleks.collection.BitArray
 import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 
@@ -123,6 +124,13 @@ class World(
     internal val entityService: EntityService
 
     /**
+     * List of all [families][Family] of the world that are created either via
+     * an [IteratingSystem] or via the world's [family] function to
+     * avoid creating duplicates.
+     */
+    private val allFamilies = mutableListOf<Family>()
+
+    /**
      * Returns the amount of active entities.
      */
     val numEntities: Int
@@ -226,6 +234,86 @@ class World(
      * a no argument constructor.
      */
     inline fun <reified T : Any> mapper(): ComponentMapper<T> = componentService.mapper(T::class)
+
+    /**
+     * Creates a new [WorldFamily] for the given [allOf], [noneOf] and [anyOf] component configuration.
+     *
+     * This function internally either creates or reuses an already existing [family][Family].
+     * In case a new [family][Family] gets created it will be initialized with any already existing [entity][Entity]
+     * that matches its configuration.
+     * Therefore, this might have a performance impact on the first call if there are a lot of entities in the world.
+     *
+     * As a best practice families should be created as early as possible, ideally during world creation.
+     * Also, store the result of this function instead of calling this function multiple times with the same arguments.
+     *
+     * @throws [FleksFamilyException] if [allOf], [noneOf] and [anyOf] are null or empty.
+     */
+    fun family(
+        allOf: Array<KClass<*>>? = null,
+        noneOf: Array<KClass<*>>? = null,
+        anyOf: Array<KClass<*>>? = null,
+    ): WorldFamily {
+        val allOfCmps = if (allOf != null && allOf.isNotEmpty()) {
+            allOf.map { componentService.mapper(it) }
+        } else {
+            null
+        }
+
+        val noneOfCmps = if (noneOf != null && noneOf.isNotEmpty()) {
+            noneOf.map { componentService.mapper(it) }
+        } else {
+            null
+        }
+
+        val anyOfCmps = if (anyOf != null && anyOf.isNotEmpty()) {
+            anyOf.map { componentService.mapper(it) }
+        } else {
+            null
+        }
+
+        return WorldFamily(
+            familyOfMappers(allOfCmps, noneOfCmps, anyOfCmps),
+            entityService
+        )
+    }
+
+    /**
+     * Creates or returns an already created [family][Family] for the given
+     * [allOf], [noneOf] and [anyOf] component configuration.
+     *
+     * Also, adds a newly created [family][Family] as [EntityListener] and
+     * initializes it by notifying it with any already existing [entity][Entity]
+     * that matches its configuration.
+     *
+     * @throws [FleksFamilyException] if [allOf], [noneOf] and [anyOf] are null or empty.
+     */
+    internal fun familyOfMappers(
+        allOf: List<ComponentMapper<*>>?,
+        noneOf: List<ComponentMapper<*>>?,
+        anyOf: List<ComponentMapper<*>>?,
+    ): Family {
+        if ((allOf == null || allOf.isEmpty())
+            && (noneOf == null || noneOf.isEmpty())
+            && (anyOf == null || anyOf.isEmpty())
+        ) {
+            throw FleksFamilyException(allOf, noneOf, anyOf)
+        }
+
+        val allBs = if (allOf == null) null else BitArray().apply { allOf.forEach { this.set(it.id) } }
+        val noneBs = if (noneOf == null) null else BitArray().apply { noneOf.forEach { this.set(it.id) } }
+        val anyBs = if (anyOf == null) null else BitArray().apply { anyOf.forEach { this.set(it.id) } }
+
+        var family = allFamilies.find { it.allOf == allBs && it.noneOf == noneBs && it.anyOf == anyBs }
+        if (family == null) {
+            family = Family(allBs, noneBs, anyBs).apply {
+                entityService.addEntityListener(this)
+                allFamilies.add(this)
+                // initialize a newly created family by notifying it for any already existing entity
+                entityService.forEach { this.onEntityCfgChanged(it, entityService.cmpMasks[it.id]) }
+            }
+        }
+        return family
+    }
 
     /**
      * Updates all [enabled][IntervalSystem.enabled] [systems][IntervalSystem] of the world


### PR DESCRIPTION
I decided to go for a `WorldFamily` wrapper instead of exposion the `Family` itself because of the way sorting and iteration has to be performed. As a reference here is how an `IteratingSystem` works:

```kotlin
 /**
     * Updates the [family] if needed and calls [onTickEntity] for each [entity][Entity] of the [family].
     * If [doSort] is true then [entities][Entity] are sorted using the [comparator] before calling [onTickEntity].
     *
     * **Important note**: There is a potential risk when iterating over entities and one of those entities
     * gets removed. Removing the entity immediately and cleaning up its components could
     * cause problems because if you access a component which is mandatory for the family, you will get
     * a FleksNoSuchComponentException. To avoid that you could check if an entity really has the component
     * before accessing it but that is redundant in context of a family.
     *
     * To avoid these kinds of issues, entity removals are delayed until the end of the iteration. This also means
     * that a removed entity of this family will still be part of the [onTickEntity] for the current iteration.
     */
 override fun onTick() {
        if (family.isDirty) {
            family.updateActiveEntities()
        }
        if (doSort) {
            doSort = sortingType == Automatic
            family.sort(comparator)
        }

        entityService.delayRemoval = true
        family.forEach { onTickEntity(it) }
        entityService.cleanupDelays()
    }
```

Before sorting or iteration it checks if the family is dirty (=entities got added/removed) and updates it. This only needs to be done once at the beginning and is therefore not so easy to move it inside the family directly.

Also, before iteration we need to delay the removal of entities as described in the comment. This would mean we need to give a family access to the entityService internally which I also did not like.

Therefore, a `WorldFamily` wrapper got created that contains a similar logic as the `onTick` function but keeps the original `Family` object clean.