### PR TITLE
Release/1.3 jvm

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -400,11 +400,16 @@ The world's `forEach` function allows you to iterate over all active entities:
 }
 ```
 
+### Family
+
 In case you need to iterate over entities with a specific component configuration
 that is not part of a system then this is possible via the `family` function
 of a `world`. 
 A `family` keeps track of entities with a specific config and allows sorting
-and iteration over these entities. The following example shows how to
+and iteration over these entities. `Family` is used internally
+by an `IteratingSystem`. You can access it via the `family` property.
+
+The following example shows how to
 get a `family` for entities with a MoveComponent but without a DeadComponent:
 
 ```kotlin
@@ -445,6 +450,37 @@ fun main() {
 }
 ```
 
+Families also support `FamilyListener` that allow you to react when an entity
+gets added to, or removed from a `family`. Here is an example:
+
+```kotlin
+fun main() {
+    val familyListener = object : FamilyListener {
+        override fun onEntityAdded(entity: Entity) {
+            // do something when an entity gets added to the family
+        }
+
+        override fun onEntityRemoved(entity: Entity) {
+            // do something when an entity gets removed of a family
+        }
+    }
+    val world = World {}
+    val family = world.family(
+        allOf = arrayOf(MoveComponent::class),
+        noneOf = arrayOf(DeadComponent::class),
+    )
+    family.addFamilyListener(familyListener)
+
+    // this will notify the listener via its onEntityAdded function
+    val entity = world.entity {
+        add<MoveComponent>()
+        add<DeadComponent>()
+    }
+
+    // this will notify the listener via its onEntityRemoved function
+    world.remove(entity)
+}
+```
 
 ### Entity and Components
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -437,7 +437,10 @@ fun main() {
     // 1) e3
     // 2) e1
     family.forEach { entity ->
-        // do something with the entity
+        // family also supports the configureEntity function
+        configureEntity(entity) {
+            // update entity components
+        }
     }
 }
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,7 +1,7 @@
 # Fleks
 
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Quillraven/Fleks/blob/master/LICENSE)
-[![Maven](https://img.shields.io/badge/Maven-1.2--JVM-success.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/1.2-JVM/jar)
+[![Maven](https://img.shields.io/badge/Maven-1.3--JVM-success.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/1.3-JVM/jar)
 
 [![Build Master](https://img.shields.io/github/workflow/status/quillraven/fleks/Build/master?event=push&label=Build%20master)](https://github.com/Quillraven/fleks/actions)
 [![Kotlin](https://img.shields.io/badge/Kotlin-1.6.21-red.svg)](http://kotlinlang.org/)
@@ -63,20 +63,20 @@ To use Fleks add it as a dependency to your project:
 <dependency>
   <groupId>io.github.quillraven.fleks</groupId>
   <artifactId>Fleks</artifactId>
-  <version>1.2-JVM</version>
+  <version>1.3-JVM</version>
 </dependency>
 ```
 
 #### Gradle (Groovy)
 
 ```kotlin
-implementation 'io.github.quillraven.fleks:Fleks:1.2-JVM'
+implementation 'io.github.quillraven.fleks:Fleks:1.3-JVM'
 ```
 
 #### Gradle (Kotlin)
 
 ```kotlin
-implementation("io.github.quillraven.fleks:Fleks:1.2-JVM")
+implementation("io.github.quillraven.fleks:Fleks:1.3-JVM")
 ```
 
 ## Example game using Fleks

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "io.github.quillraven.fleks"
-version = "1.2-JVM"
+version = "1.3-JVM"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 val bmSourceSetName = "benchmarks"

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -163,6 +163,7 @@ class EntityService(
      * In such cases entities will not be removed immediately.
      * Refer to [IteratingSystem.onTick] for more details.
      */
+    @PublishedApi
     internal var delayRemoval = false
 
     /**

--- a/src/main/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/exception.kt
@@ -10,6 +10,9 @@ class FleksSystemAlreadyAddedException(system: KClass<*>) :
 class FleksSystemCreationException(system: KClass<*>, details: String) :
     FleksException("Cannot create ${system.simpleName}. Did you add all necessary injectables?\nDetails: $details")
 
+class FleksFamilyListenerCreationException(listener: KClass<*>, details: String) :
+    FleksException("Cannot create ${listener.simpleName}.\nDetails: $details")
+
 class FleksNoSuchSystemException(system: KClass<*>) :
     FleksException("There is no system of type ${system.simpleName} in the world")
 
@@ -27,6 +30,9 @@ class FleksNoSuchComponentException(entity: Entity, component: String) :
 
 class FleksComponentListenerAlreadyAddedException(listener: KClass<out ComponentListener<*>>) :
     FleksException("ComponentListener ${listener.simpleName} is already part of the ${WorldConfiguration::class.simpleName}")
+
+class FleksFamilyListenerAlreadyAddedException(listener: KClass<out FamilyListener>) :
+    FleksException("FamilyListener ${listener.simpleName} is already part of the ${WorldConfiguration::class.simpleName}")
 
 class FleksUnusedInjectablesException(unused: List<KClass<*>>) :
     FleksException("There are unused injectables of following types: ${unused.map { it.simpleName }}")

--- a/src/main/kotlin/com/github/quillraven/fleks/reflection.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/reflection.kt
@@ -75,3 +75,10 @@ internal fun systemArgs(
 
     return args
 }
+
+/**
+ * Returns [Annotation] of the specific type if the class has that annotation. Otherwise, returns null.
+ */
+inline fun <reified T : Annotation> KClass<*>.annotation(): T? {
+    return this.java.getAnnotation(T::class.java)
+}

--- a/src/main/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/system.kt
@@ -158,28 +158,13 @@ abstract class IteratingSystem(
     /**
      * Updates the [family] if needed and calls [onTickEntity] for each [entity][Entity] of the [family].
      * If [doSort] is true then [entities][Entity] are sorted using the [comparator] before calling [onTickEntity].
-     *
-     * **Important note**: There is a potential risk when iterating over entities and one of those entities
-     * gets removed. Removing the entity immediately and cleaning up its components could
-     * cause problems because if you access a component which is mandatory for the family, you will get
-     * a FleksNoSuchComponentException. To avoid that you could check if an entity really has the component
-     * before accessing it but that is redundant in context of a family.
-     *
-     * To avoid these kinds of issues, entity removals are delayed until the end of the iteration. This also means
-     * that a removed entity of this family will still be part of the [onTickEntity] for the current iteration.
      */
     override fun onTick() {
-        if (family.isDirty) {
-            family.updateActiveEntities()
-        }
         if (doSort) {
             doSort = sortingType == Automatic
             family.sort(comparator)
         }
-
-        entityService.delayRemoval = true
         family.forEach { onTickEntity(it) }
-        entityService.cleanupDelays()
     }
 
     /**
@@ -194,13 +179,7 @@ abstract class IteratingSystem(
      * @param alpha a value between 0 (inclusive) and 1 (exclusive) that describes the progress between two ticks.
      */
     override fun onAlpha(alpha: Float) {
-        if (family.isDirty) {
-            family.updateActiveEntities()
-        }
-
-        entityService.delayRemoval = true
         family.forEach { onAlphaEntity(it, alpha) }
-        entityService.cleanupDelays()
     }
 
     /**

--- a/src/main/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/system.kt
@@ -225,8 +225,9 @@ class SystemService(
                 // create family for IteratingSystem that gets created below.
                 // This is needed because if the user wants to access the family in the system's constructor
                 // then it must be already set. Therefore, it must happen during creation and not afterwards.
-                // We do this like we do it for the world via its CURRENT_WORLD global.
-                Family.CURRENT_FAMILY = familyOfSystem(allOfAnn, noneOfAnn, anyOfAnn, world, cmpService)
+                // We do this like we do it for the world and its CURRENT_WORLD global
+                // but this time using a CURRENT_FAMILY global.
+                Family.CURRENT_FAMILY = world.familyOfAnnotations(allOfAnn, noneOfAnn, anyOfAnn)
             }
 
             val system = newInstance(sysType, cmpService, injectables)
@@ -238,51 +239,6 @@ class SystemService(
             }
             system
         }
-    }
-
-    /**
-     * Returns [Annotation] of the specific type if the class has that annotation. Otherwise, returns null.
-     */
-    private inline fun <reified T : Annotation> KClass<*>.annotation(): T? {
-        return this.java.getAnnotation(T::class.java)
-    }
-
-    /**
-     * Creates or returns an already created [family][Family] for the given [IteratingSystem]
-     * by analyzing the system's [AllOf], [AnyOf] and [NoneOf] annotations.
-     *
-     * @throws [FleksSystemCreationException] if the [IteratingSystem] does not contain at least one
-     * [AllOf], [AnyOf] or [NoneOf] annotation.
-     *
-     * @throws [FleksMissingNoArgsComponentConstructorException] if the [AllOf], [NoneOf] or [AnyOf] annotations
-     * of the system have a component type that does not have a no argument constructor.
-     */
-    private fun familyOfSystem(
-        allOfAnn: AllOf?,
-        noneOfAnn: NoneOf?,
-        anyOfAnn: AnyOf?,
-        world: World,
-        cmpService: ComponentService
-    ): Family {
-        val allOfCmps = if (allOfAnn != null && allOfAnn.components.isNotEmpty()) {
-            allOfAnn.components.map { cmpService.mapper(it) }
-        } else {
-            null
-        }
-
-        val noneOfCmps = if (noneOfAnn != null && noneOfAnn.components.isNotEmpty()) {
-            noneOfAnn.components.map { cmpService.mapper(it) }
-        } else {
-            null
-        }
-
-        val anyOfCmps = if (anyOfAnn != null && anyOfAnn.components.isNotEmpty()) {
-            anyOfAnn.components.map { cmpService.mapper(it) }
-        } else {
-            null
-        }
-
-        return world.familyOfMappers(allOfCmps, noneOfCmps, anyOfCmps)
     }
 
     /**

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -239,7 +239,7 @@ class World(
     inline fun <reified T : Any> mapper(): ComponentMapper<T> = componentService.mapper(T::class)
 
     /**
-     * Creates a new [WorldFamily] for the given [allOf], [noneOf] and [anyOf] component configuration.
+     * Creates a new [Family] for the given [allOf], [noneOf] and [anyOf] component configuration.
      *
      * This function internally either creates or reuses an already existing [family][Family].
      * In case a new [family][Family] gets created it will be initialized with any already existing [entity][Entity]
@@ -255,7 +255,7 @@ class World(
         allOf: Array<KClass<*>>? = null,
         noneOf: Array<KClass<*>>? = null,
         anyOf: Array<KClass<*>>? = null,
-    ): WorldFamily {
+    ): Family {
         val allOfCmps = if (allOf != null && allOf.isNotEmpty()) {
             allOf.map { componentService.mapper(it) }
         } else {
@@ -274,10 +274,7 @@ class World(
             null
         }
 
-        return WorldFamily(
-            familyOfMappers(allOfCmps, noneOfCmps, anyOfCmps),
-            entityService
-        )
+        return familyOfMappers(allOfCmps, noneOfCmps, anyOfCmps)
     }
 
     /**
@@ -308,7 +305,7 @@ class World(
 
         var family = allFamilies.find { it.allOf == allBs && it.noneOf == noneBs && it.anyOf == anyBs }
         if (family == null) {
-            family = Family(allBs, noneBs, anyBs).apply {
+            family = Family(allBs, noneBs, anyBs, entityService).apply {
                 entityService.addEntityListener(this)
                 allFamilies.add(this)
                 // initialize a newly created family by notifying it for any already existing entity

--- a/src/test/kotlin/com/github/quillraven/fleks/FamilyTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/FamilyTest.kt
@@ -211,4 +211,37 @@ internal class FamilyTest {
         assertEquals(2, numOuterIterations)
         assertEquals(4, numInnerIterations)
     }
+
+    @Test
+    fun `test FamilyListener`() {
+        val requiredCmps = BitArray().apply { set(1) }
+        val e = Entity(0)
+        val listener = object : FamilyListener {
+            var numAdd = 0
+            var numRemove = 0
+
+            override fun onEntityAdded(entity: Entity) {
+                ++numAdd
+            }
+
+            override fun onEntityRemoved(entity: Entity) {
+                ++numRemove
+            }
+        }
+        val family = Family(allOf = requiredCmps, entityService = testEntityService)
+
+        family.addFamilyListener(listener)
+        assertTrue { listener in family }
+
+        family.onEntityCfgChanged(e, requiredCmps)
+        assertEquals(1, listener.numAdd)
+        assertEquals(0, listener.numRemove)
+
+        family.onEntityCfgChanged(e, BitArray())
+        assertEquals(1, listener.numAdd)
+        assertEquals(1, listener.numRemove)
+
+        family.removeFamilyListener(listener)
+        assertFalse { listener in family }
+    }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -79,8 +79,15 @@ private class WorldTestNamedDependencySystem(
 private class WorldTestComponentListener(
     val world: World
 ) : ComponentListener<WorldTestComponent> {
-    override fun onComponentAdded(entity: Entity, component: WorldTestComponent) = Unit
-    override fun onComponentRemoved(entity: Entity, component: WorldTestComponent) = Unit
+    var numAdd = 0
+    var numRemove = 0
+    override fun onComponentAdded(entity: Entity, component: WorldTestComponent) {
+        ++numAdd
+    }
+
+    override fun onComponentRemoved(entity: Entity, component: WorldTestComponent) {
+        ++numRemove
+    }
 }
 
 internal class WorldTest {
@@ -411,5 +418,18 @@ internal class WorldTest {
 
         assertThrows<FleksFamilyException> { w.family() }
         assertThrows<FleksFamilyException> { w.family(arrayOf(), arrayOf(), arrayOf()) }
+    }
+
+    @Test
+    fun `notify ComponentListener during system creation`() {
+        val w = World {
+            system<WorldTestInitSystem>()
+
+            componentListener<WorldTestComponentListener>()
+        }
+        val listener = w.mapper<WorldTestComponent>().listeners[0] as WorldTestComponentListener
+
+        assertEquals(1, listener.numAdd)
+        assertEquals(0, listener.numRemove)
     }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -353,7 +353,7 @@ internal class WorldTest {
     }
 
     @Test
-    fun `get WorldFamily after world creation`() {
+    fun `get Family after world creation`() {
         // WorldTestInitSystem creates an entity in its init block
         // -> family must be dirty and has a size of 1
         val w = World {
@@ -363,13 +363,13 @@ internal class WorldTest {
         val wFamily = w.family(allOf = arrayOf(WorldTestComponent::class))
 
         assertAll(
-            { assertTrue(wFamily.family.isDirty) },
-            { assertEquals(1, wFamily.family.numEntities) }
+            { assertTrue(wFamily.isDirty) },
+            { assertEquals(1, wFamily.numEntities) }
         )
     }
 
     @Test
-    fun `get WorldFamily within system's constructor`() {
+    fun `get Family within system's constructor`() {
         // WorldTestInitSystemExtraFamily creates an entity in its init block and
         // also a family with a different configuration that the system itself
         // -> system family is empty and extra family contains 1 entity
@@ -379,13 +379,13 @@ internal class WorldTest {
         val s = w.system<WorldTestInitSystemExtraFamily>()
 
         assertAll(
-            { assertEquals(1, s.extraFamily.family.numEntities) },
+            { assertEquals(1, s.extraFamily.numEntities) },
             { assertEquals(0, s.family.numEntities) }
         )
     }
 
     @Test
-    fun `iterate over WorldFamily`() {
+    fun `iterate over Family`() {
         val w = World {}
         val e1 = w.entity { add<WorldTestComponent>() }
         val e2 = w.entity { add<WorldTestComponent>() }
@@ -398,7 +398,7 @@ internal class WorldTest {
     }
 
     @Test
-    fun `sorted iteration over WorldFamily`() {
+    fun `sorted iteration over Family`() {
         val w = World {}
         val e1 = w.entity { add<WorldTestComponent> { x = 15f } }
         val e2 = w.entity { add<WorldTestComponent> { x = 10f } }
@@ -410,6 +410,24 @@ internal class WorldTest {
         f.forEach { actualEntities.add(it) }
 
         assertEquals(arrayListOf(e2, e1), actualEntities)
+    }
+
+    @Test
+    fun `configure entity during Family iteration`() {
+        // family excludes entities of Component2 which gets added during iteration
+        // -> family must be empty after iteration
+        val w = World {}
+        w.entity { add<WorldTestComponent>() }
+        val f = w.family(allOf = arrayOf(WorldTestComponent::class), noneOf = arrayOf(WorldTestComponent2::class))
+        val mapper = w.mapper<WorldTestComponent2>()
+
+        f.forEach { entity ->
+            this.configureEntity(entity) {
+                mapper.add(it)
+            }
+        }
+
+        assertEquals(0, f.numEntities)
     }
 
     @Test


### PR DESCRIPTION
- [x] BUGFIX: `ComponentListener` did not get notified when entities are created in a system's `init` block
- [x] BUGFIX: nested `Family` iteration was not properly handled when entities got removed during iteration. The entity removal delay was removed by the inner loop instead of the outer
- [x] NEW: users have now access to the `family` of an `IteratingSystem` 
- [x] NEW: `family` now also contains a `configureEntity` function which allows users to modify an entity outside of a system in a convenient way
- [x] NEW: a new `FamilyListener` support is added which allows users to react on when an entity is added to, or removed from a `family`   

----

This PR removes the `WorldFamily` of the previous version. With the introduction of `FamilyListener` I felt that too much code needs to be redundant/copied in both areas `Family` and `WorldFamily`. To make it easier I decided to just keep the `Family` with the downside - if you want - that it now needs to have a reference to the `EntityService` to properly support iterationg and sorting when called outside of a system.