### PR TITLE
Deprecate global inject object for world local injections.

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/Injections.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/Injections.kt
@@ -1,0 +1,45 @@
+package com.github.quillraven.fleks
+
+/**
+ * An [injector][Injections] which is used to inject objects from outside the [IntervalSystem].
+ *
+ * @throws [FleksSystemDependencyInjectException] if the Injector does not contain an entry
+ * for the given type in its internal map.
+ * @throws [FleksSystemComponentInjectException] if the Injector does not contain a component mapper
+ * for the given type in its internal map.
+ * @throws [FleksInjectableTypeHasNoName] if the dependency type has no T::class.simpleName.
+ */
+data class Injections(
+    @PublishedApi
+    internal val injectObjects: Map<String, Injectable> = mapOf(),
+    @PublishedApi
+    internal val mapperObjects: Map<String, ComponentMapper<*>> = mapOf()
+
+) {
+    inline fun <reified T : Any> dependency(): T {
+        val injectType = T::class.simpleName ?: throw FleksInjectableTypeHasNoName(T::class)
+        return if (injectType in injectObjects) {
+            injectObjects[injectType]!!.used = true
+            injectObjects[injectType]!!.injObj as T
+        } else throw FleksSystemDependencyInjectException(injectType)
+    }
+
+    inline fun <reified T : Any> dependency(type: String): T {
+        return if (type in injectObjects) {
+            injectObjects[type]!!.used = true
+            injectObjects[type]!!.injObj as T
+        } else throw FleksSystemDependencyInjectException(type)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : Any> componentMapper(): ComponentMapper<T> {
+        val injectType = T::class.simpleName ?: throw FleksInjectableTypeHasNoName(T::class)
+        return if (injectType in mapperObjects) {
+            mapperObjects[injectType]!! as ComponentMapper<T>
+        } else throw FleksSystemComponentInjectException(injectType)
+    }
+
+    companion object {
+        val EMPTY = Injections()
+    }
+}

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -1,6 +1,7 @@
 package com.github.quillraven.fleks.collection
 
 import com.github.quillraven.fleks.Entity
+import com.github.quillraven.fleks.Injections
 import kotlin.math.max
 import kotlin.math.min
 
@@ -139,11 +140,13 @@ class IntBag(
  * Sorting of int[] logic taken from: https://github.com/karussell/fastutil/blob/master/src/it/unimi/dsi/fastutil/ints/IntArrays.java
  */
 interface EntityComparator {
+    val injections: Injections
     fun compare(entityA: Entity, entityB: Entity): Int
 }
 
-fun compareEntity(compareFun: (Entity, Entity) -> Int): EntityComparator {
+fun compareEntity(injections: Injections, compareFun: (Entity, Entity) -> Int): EntityComparator {
     return object : EntityComparator {
+        override val injections: Injections = injections
         override fun compare(entityA: Entity, entityB: Entity): Int {
             return compareFun(entityA, entityB)
         }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -9,6 +9,7 @@ import kotlin.math.max
  * gets added or removed from an [entity][Entity].
  */
 interface ComponentListener<T> {
+    val injections: Injections
     fun onComponentAdded(entity: Entity, component: T)
     fun onComponentRemoved(entity: Entity, component: T)
 }
@@ -78,7 +79,7 @@ class ComponentMapper<T>(
      * Removes a component of the specific type from the given [entity].
      * Notifies any registered [ComponentListener].
      *
-     * @throws [IndexOutOfBoundsException] if the id of the [entity] exceeds the components' capacity.
+     * @throws [ArrayIndexOutOfBoundsException] if the id of the [entity] exceeds the components' capacity.
      */
     @PublishedApi
     internal fun removeInternal(entity: Entity) {
@@ -172,7 +173,7 @@ class ComponentService(
     /**
      * Returns a [ComponentMapper] for the specific type.
      *
-     * @throws [FleksNoSuchComponentException] if the component of the given type does not exist in the
+     * @throws [FleksNoSuchComponentException] if the component of the given [type] does not exist in the
      * world configuration.
      */
     @Suppress("UNCHECKED_CAST")

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -91,7 +91,7 @@ class EntityUpdateCfg {
      * Removes a component of the given type from the [entity].
      * Notifies any registered [ComponentListener].
      *
-     * @throws [IndexOutOfBoundsException] if the id of the [entity] exceeds the mapper's capacity.
+     * @throws [ArrayIndexOutOfBoundsException] if the id of the [entity] exceeds the mapper's capacity.
      */
     inline fun <reified T : Any> ComponentMapper<T>.remove(entity: Entity) {
         compMask.clear(this.id)

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -23,13 +23,13 @@ class WorldConfiguration {
     var entityCapacity = 512
 
     @PublishedApi
-    internal val systemFactory = mutableMapOf<KClass<*>, () -> IntervalSystem>()
+    internal val systemFactory = mutableMapOf<KClass<*>, (injections: Injections) -> IntervalSystem>()
 
     @PublishedApi
     internal val injectables = mutableMapOf<String, Injectable>()
 
     @PublishedApi
-    internal val compListenerFactory = mutableMapOf<String, () -> ComponentListener<*>>()
+    internal val compListenerFactory = mutableMapOf<String, (injections: Injections) -> ComponentListener<*>>()
 
     @PublishedApi
     internal val componentFactory = mutableMapOf<String, () -> Any>()
@@ -41,7 +41,7 @@ class WorldConfiguration {
      * @param factory A function which creates an object of type [T].
      * @throws [FleksSystemAlreadyAddedException] if the system was already added before.
      */
-    inline fun <reified T : IntervalSystem> system(noinline factory: () -> T) {
+    inline fun <reified T : IntervalSystem> system(noinline factory: (injections: Injections) -> T) {
         val systemType = T::class
         if (systemType in systemFactory) {
             throw FleksSystemAlreadyAddedException(systemType)
@@ -83,7 +83,7 @@ class WorldConfiguration {
     }
 
     /**
-     * Adds the specified component and its [ComponentListener] to the [world][World]. If a component listener
+     * Adds the specified [Component] and its [ComponentListener] to the [world][World]. If a component listener
      * is not needed than it can be omitted.
      *
      * @param compFactory the constructor method for creating the component.
@@ -91,7 +91,7 @@ class WorldConfiguration {
      * @throws [FleksComponentAlreadyAddedException] if the component was already added before.
      * @throws [FleksInjectableTypeHasNoName] if the dependency type has no T::class.simpleName.
      */
-    inline fun <reified T : Any> component(noinline compFactory: () -> T, noinline listenerFactory: (() -> ComponentListener<T>)? = null) {
+    inline fun <reified T : Any> component(noinline compFactory: () -> T, noinline listenerFactory: ((injections: Injections) -> ComponentListener<T>)? = null) {
         val compType = T::class.simpleName ?: throw FleksInjectableTypeHasNoName(T::class)
 
         if (compType in componentFactory) {
@@ -152,12 +152,14 @@ class World(
         // Set "used" to true to make this injectable not mandatory
         injectables["World"] = Injectable(this, true)
 
-        systemService = SystemService(this, worldCfg.systemFactory, injectables)
+        val injections = Injections(injectables, componentService.mappers)
+
+        systemService = SystemService(this, worldCfg.systemFactory, injections)
 
         // create and register ComponentListener
         worldCfg.compListenerFactory.forEach {
             val compType = it.key
-            val listener = it.value.invoke()
+            val listener = it.value.invoke(injections)
             val mapper = componentService.mapper(compType)
             mapper.addComponentListenerInternal(listener)
         }
@@ -174,6 +176,13 @@ class World(
      */
     inline fun entity(configuration: EntityCreateCfg.(Entity) -> Unit = {}): Entity {
         return entityService.create(configuration)
+    }
+
+    /**
+     * Updates an [entity] using the given [configuration] to add and remove components.
+     */
+    inline fun configureEntity(entity: Entity, configuration: EntityUpdateCfg.(Entity) -> Unit) {
+        entityService.configureEntity(entity, configuration)
     }
 
     /**
@@ -211,7 +220,7 @@ class World(
     /**
      * Returns a [ComponentMapper] for the given type. If the mapper does not exist then it will be created.
      *
-     * @throws [FleksNoSuchComponentException] if the component of the given type does not exist in the
+     * @throws [FleksNoSuchComponentException] if the component of the given [type] does not exist in the
      * world configuration.
      * @throws [FleksInjectableTypeHasNoName] if the dependency type has no T::class.simpleName.
      */

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTest.kt
@@ -1,10 +1,7 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.BitArray
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 private class EntityTestListener : EntityListener {
     var numCalls = 0
@@ -144,7 +141,7 @@ internal class EntityTest {
     }
 
     @Test
-    fun removeEntityWithComponentImmediatelyWithCustomListener() {
+    fun removeEntityWithAComponentImmediatelyWithCustomListener() {
         val cmpService = ComponentService(componentFactory)
         val entityService = EntityService(32, cmpService)
         val listener = EntityTestListener()

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/FamilyTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/FamilyTest.kt
@@ -15,10 +15,9 @@ internal class FamilyTest {
         }
     }
 
-
     @Test
-    fun testContains() {
-        val testCases = listOf(
+    fun testFamily() {
+        listOf(
             arrayOf(
                 "empty family contains entity without components",
                 BitArray(), // entity component mask
@@ -67,9 +66,7 @@ internal class FamilyTest {
                 0, 0, 1,                     // family allOf, noneOf, anyOf indices
                 true                         // expected
             ),
-        )
-
-        testCases.forEach {
+        ).map {
             val eCmpMask = it[1] as BitArray
             val fAllOf = createCmpBitmask(it[2] as Int)
             val fNoneOf = createCmpBitmask(it[3] as Int)
@@ -77,7 +74,7 @@ internal class FamilyTest {
             val family = Family(fAllOf, fNoneOf, fAnyOf)
             val expected = it[5] as Boolean
 
-            assertEquals(expected, eCmpMask in family)
+            assertEquals(expected, eCmpMask in family, "FAILED: testFamily: " + it[0] + " - ")
         }
     }
 
@@ -119,7 +116,7 @@ internal class FamilyTest {
         family.updateActiveEntities()
 
         // sort descending by entity id
-        family.sort(compareEntity { e1, e2 -> e2.id.compareTo(e1.id) })
+        family.sort(compareEntity(Injections()) { e1, e2 -> e2.id.compareTo(e1.id) })
 
         assertEquals(2, family.entitiesBag[0])
         assertEquals(1, family.entitiesBag[1])
@@ -128,16 +125,14 @@ internal class FamilyTest {
 
     @Test
     fun testOnEntityCfgChange() {
-        val testCases = listOf(
+        listOf(
             // first = add entity to family before calling onChange
             // second = make entity part of family
             Pair(false, false),
             Pair(false, true),
             Pair(true, false),
             Pair(true, true),
-        )
-
-        testCases.forEach {
+        ).map {
             val family = Family(BitArray().apply { set(1) }, null, null)
             val addEntityBeforeCall = it.first
             val addEntityToFamily = it.second
@@ -150,11 +145,11 @@ internal class FamilyTest {
             if (addEntityToFamily) {
                 family.onEntityCfgChanged(entity, BitArray().apply { set(1) })
 
-                assertEquals(!addEntityBeforeCall, family.isDirty)
+                assertEquals(!addEntityBeforeCall, family.isDirty, "FAILED: testOnEntityCfgChanged: addEntityBefore=${it.first}, addEntity=${it.second} - ")
             } else {
                 family.onEntityCfgChanged(entity, BitArray())
 
-                assertEquals(addEntityBeforeCall, family.isDirty)
+                assertEquals(addEntityBeforeCall, family.isDirty, "FAILED: testOnEntityCfgChanged: addEntityBefore=${it.first}, addEntity=${it.second} - ")
             }
         }
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -1,10 +1,17 @@
 package com.github.quillraven.fleks
 
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 private data class WorldTestComponent(var x: Float = 0f)
 
-private class WorldTestIntervalSystem : IntervalSystem() {
+private class WorldTestIntervalSystem(
+    injections: Injections
+) : IntervalSystem(injections) {
     var numCalls = 0
     var disposed = false
 
@@ -17,13 +24,16 @@ private class WorldTestIntervalSystem : IntervalSystem() {
     }
 }
 
-private class WorldTestIteratingSystem : IteratingSystem(
+private class WorldTestIteratingSystem(
+    injections: Injections
+) : IteratingSystem(
+    injections,
     allOfComponents = arrayOf(WorldTestComponent::class)
 ) {
     var numCalls = 0
 
-    val testInject: String = Inject.dependency()
-    val mapper: ComponentMapper<WorldTestComponent> = Inject.componentMapper()
+    val testInject: String = injections.dependency()
+    val mapper: ComponentMapper<WorldTestComponent> = injections.componentMapper()
 
     override fun onTick() {
         ++numCalls
@@ -33,16 +43,17 @@ private class WorldTestIteratingSystem : IteratingSystem(
     override fun onTickEntity(entity: Entity) = Unit
 }
 
-private class WorldTestNamedDependencySystem : IntervalSystem() {
-    val injName: String = Inject.dependency("name")
-    val level: String = Inject.dependency("level")
+private class WorldTestNamedDependencySystem(injections: Injections) : IntervalSystem(injections) {
+    val _name: String = injections.dependency("name")
+    val level: String = injections.dependency("level")
 
-    val name: String = injName
+    val name: String = _name
 
     override fun onTick() = Unit
 }
 
-private class WorldTestComponentListener : ComponentListener<WorldTestComponent> {
+private class WorldTestComponentListener(override val injections: Injections) :
+    ComponentListener<WorldTestComponent> {
     override fun onComponentAdded(entity: Entity, component: WorldTestComponent) = Unit
     override fun onComponentRemoved(entity: Entity, component: WorldTestComponent) = Unit
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/collection/BagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/collection/BagTest.kt
@@ -1,6 +1,11 @@
 package com.github.quillraven.fleks.collection
 
-import kotlin.test.*
+import com.github.quillraven.fleks.Injections
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class GenericBagTest {
     @Test
@@ -142,6 +147,13 @@ class IntBagTest {
     }
 
     @Test
+    fun addValueUnsafeWithInsufficientCapacity() {
+        val bag = IntBag(0)
+
+        assertFailsWith<IndexOutOfBoundsException> { bag.unsafeAdd(42) }
+    }
+
+    @Test
     fun addValueToBagWithInsufficientCapacity() {
         val bag = IntBag(0)
 
@@ -150,6 +162,13 @@ class IntBagTest {
         assertEquals(1, bag.size)
         assertEquals(42, bag[0])
         assertEquals(1, bag.capacity)
+    }
+
+    @Test
+    fun cannotGetValueOfOutOfBoundsIndex() {
+        val bag = IntBag(2)
+
+        assertFailsWith<IndexOutOfBoundsException> { bag[2] }
     }
 
     @Test
@@ -183,7 +202,6 @@ class IntBagTest {
             valuesCalled.add(it)
         }
 
-
         assertEquals(2, numCalls)
         assertEquals(listOf(42, 43), valuesCalled)
     }
@@ -193,7 +211,7 @@ class IntBagTest {
         val bag = IntBag()
         repeat(6) { bag.add(6 - it) }
 
-        bag.sort(compareEntity { e1, e2 -> e1.id.compareTo(e2.id) })
+        bag.sort(compareEntity(Injections.EMPTY) { e1, e2 -> e1.id.compareTo(e2.id) })
 
         repeat(6) {
             assertEquals(it + 1, bag[it])
@@ -205,7 +223,7 @@ class IntBagTest {
         val bag = IntBag()
         repeat(8) { bag.add(8 - it) }
 
-        bag.sort(compareEntity { e1, e2 -> e1.id.compareTo(e2.id) })
+        bag.sort(compareEntity(Injections.EMPTY) { e1, e2 -> e1.id.compareTo(e2.id) })
 
         repeat(8) {
             assertEquals(it + 1, bag[it])
@@ -217,7 +235,7 @@ class IntBagTest {
         val bag = IntBag()
         repeat(51) { bag.add(51 - it) }
 
-        bag.sort(compareEntity { e1, e2 -> e1.id.compareTo(e2.id) })
+        bag.sort(compareEntity(Injections.EMPTY) { e1, e2 -> e1.id.compareTo(e2.id) })
 
         repeat(51) {
             assertEquals(it + 1, bag[it])

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/collection/BitArrayTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/collection/BitArrayTest.kt
@@ -1,9 +1,6 @@
 package com.github.quillraven.fleks.collection
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 internal class BitArrayTest {
     @Test
@@ -144,5 +141,41 @@ internal class BitArrayTest {
 
         assertEquals(3, numCalls)
         assertEquals(listOf(117, 5, 3), bitsCalled)
+    }
+
+    @Test
+    fun bitArrayEqualsToIncompatibleTypeObject() {
+        val bits = BitArray(42)
+        bits.set(3)
+        val otherBits = 42
+
+        assertEquals(false, bits.equals(otherBits))
+        assertEquals(false, bits.equals(null))
+    }
+
+    @Test
+    fun bitArrayEqualsToSameObject() {
+        val bits = BitArray(42)
+        bits.set(3)
+
+        assertEquals(true, bits == bits)
+    }
+
+    @Test
+    fun bitArrayEqualsToOtherBitArray() {
+        val bits = BitArray(42)
+        bits.set(4)
+        val otherBits = BitArray(44)
+        otherBits.set(4)
+        val bits42 = BitArray(42)
+        bits42.set(4)
+
+        assertEquals(true, bits == otherBits, "bitArray equals to another bitArray with different size")
+        assertEquals(true, bits == bits42, "bitArray equals to another bitArray with equal size")
+
+        otherBits.set(7)
+        bits42.set(7)
+        assertEquals(false, bits == otherBits, "bitArray equals not to another bitArray with different size")
+        assertEquals(false, bits == bits42, "bitArray equals not to another bitArray with equal size")
     }
 }


### PR DESCRIPTION
The idea is that each world should have their own injection space. Currently, every world that's created overwrites the previous world's injections. So you can't have 2 worlds with different injections.

This is useful for simulation/multiplayer type games where each player has their own world.

A real life example of this is that for my game, I am replicating a starcraft 2 arcade map called "Entropy TD" where each player is competing against each other with their own mazes. Each player has their own world with their own instances of injectables.

https://sc2arcade.com/map/2/148730/