### PR TITLE
(#59) fix family numEntities

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -86,8 +86,27 @@ class IntBag(
     val capacity: Int
         get() = values.size
 
+    private val isEmpty: Boolean
+        get() = size == 0
+
     val isNotEmpty: Boolean
         get() = size > 0
+
+    val first: Int
+        get() {
+            if (isEmpty) {
+                throw NoSuchElementException("Bag is empty!")
+            }
+            return values[0]
+        }
+
+    val firstOrNull: Int?
+        get() {
+            if (isEmpty) {
+                return null
+            }
+            return values[0]
+        }
 
     fun add(value: Int) {
         if (size == values.size) {

--- a/src/main/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -86,7 +86,7 @@ class IntBag(
     val capacity: Int
         get() = values.size
 
-    private val isEmpty: Boolean
+    val isEmpty: Boolean
         get() = size == 0
 
     val isNotEmpty: Boolean

--- a/src/main/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
@@ -21,6 +21,19 @@ class BitArray(
     val capacity: Int
         get() = bits.size * 64
 
+    val isNotEmpty: Boolean
+        get() {
+            for (word in bits.size - 1 downTo 0) {
+                if (bits[word] != 0L) {
+                    return true
+                }
+            }
+            return false
+        }
+
+    val isEmpty: Boolean
+        get() = !isNotEmpty
+
     operator fun get(idx: Int): Boolean {
         val word = idx / 64
         return if (word >= bits.size) {
@@ -99,6 +112,24 @@ class BitArray(
             }
         }
         return 0
+    }
+
+    /**
+     * Returns number of bits that are set in the [BitArray].
+     */
+    fun numBits(): Int {
+        var sum = 0
+        for (word in bits.size - 1 downTo 0) {
+            val bitsAtWord = bits[word]
+            if (bitsAtWord != 0L) {
+                for (bit in 63 downTo 0) {
+                    if ((bitsAtWord and (1L shl (bit % 64))) != 0L) {
+                        sum++
+                    }
+                }
+            }
+        }
+        return sum
     }
 
     inline fun forEachSetBit(action: (Int) -> Unit) {

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -159,7 +159,7 @@ data class Family(
      * @throws [NoSuchElementException] if the family has no entities.
      */
     fun first(): Entity {
-        if (!entityService.delayRemoval) {
+        if (!entityService.delayRemoval || entitiesBag.isEmpty) {
             // no iteration in process -> update entities if necessary
             updateActiveEntities()
         }
@@ -171,7 +171,7 @@ data class Family(
      * Updates this family if needed and returns its first [Entity] or null if the family has no entities.
      */
     fun firstOrNull(): Entity? {
-        if (!entityService.delayRemoval) {
+        if (!entityService.delayRemoval || entitiesBag.isEmpty) {
             // no iteration in process -> update entities if necessary
             updateActiveEntities()
         }

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -155,19 +155,27 @@ data class Family(
     }
 
     /**
-     * Returns the first [Entity] of this [Family].
+     * Updates this family if needed and returns its first [Entity].
      * @throws [NoSuchElementException] if the family has no entities.
      */
     fun first(): Entity {
-        updateActiveEntities()
+        if (!entityService.delayRemoval) {
+            // no iteration in process -> update entities if necessary
+            updateActiveEntities()
+        }
+
         return Entity(entitiesBag.first)
     }
 
     /**
-     * Returns the first [Entity] of this [Family] or null if the family has no entities.
+     * Updates this family if needed and returns its first [Entity] or null if the family has no entities.
      */
     fun firstOrNull(): Entity? {
-        updateActiveEntities()
+        if (!entityService.delayRemoval) {
+            // no iteration in process -> update entities if necessary
+            updateActiveEntities()
+        }
+
         val id = entitiesBag.firstOrNull ?: return null
         return Entity(id)
     }

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -78,9 +78,23 @@ data class Family(
 
     /**
      * Returns the number of [entities][Entity] that belong to this family.
+     * This can be an expensive call if the amount of entities is very high because it
+     * iterates through the entire underlying [BitArray].
      */
     val numEntities: Int
-        get() = entities.length()
+        get() = entities.numBits()
+
+    /**
+     * Returns true if and only if this [Family] does not contain any entity.
+     */
+    val isEmpty: Boolean
+        get() = entities.isEmpty
+
+    /**
+     * Returns true if and only if this [Family] contains at least one entity.
+     */
+    val isNotEmpty: Boolean
+        get() = entities.isNotEmpty
 
     /**
      * Flag to indicate if there are changes in the [entities]. If it is true then the [entitiesBag] should get
@@ -138,6 +152,24 @@ data class Family(
         } else {
             entitiesBag.forEach { this.action(Entity(it)) }
         }
+    }
+
+    /**
+     * Returns the first [Entity] of this [Family].
+     * @throws [NoSuchElementException] if the family has no entities.
+     */
+    fun first(): Entity {
+        updateActiveEntities()
+        return Entity(entitiesBag.first)
+    }
+
+    /**
+     * Returns the first [Entity] of this [Family] or null if the family has no entities.
+     */
+    fun firstOrNull(): Entity? {
+        updateActiveEntities()
+        val id = entitiesBag.firstOrNull ?: return null
+        return Entity(id)
     }
 
     /**

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -227,7 +227,7 @@ data class Family(
     fun removeFamilyListener(listener: FamilyListener) = listeners.removeValue(listener)
 
     /**
-     * Returns true if an only if the given [listener] is part of the list of [FamilyListener].
+     * Returns true if and only if the given [listener] is part of the list of [FamilyListener].
      */
     operator fun contains(listener: FamilyListener) = listener in listeners
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/collection/BitArrayTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/collection/BitArrayTest.kt
@@ -162,4 +162,25 @@ internal class BitArrayTest {
             { assertEquals(listOf(117, 5, 3), bitsCalled) }
         )
     }
+
+    @Test
+    fun `test numBits`() {
+        val bits = BitArray()
+
+        bits.set(4)
+
+        assertEquals(1, bits.numBits())
+        assertEquals(5, bits.length())
+    }
+
+    @Test
+    fun `test isEmpty`() {
+        val bits = BitArray()
+        assertTrue(bits.isEmpty)
+        assertFalse(bits.isNotEmpty)
+
+        bits.set(0)
+        assertFalse(bits.isEmpty)
+        assertTrue(bits.isNotEmpty)
+    }
 }


### PR DESCRIPTION
- fix numEntities
- add isEmpty and isNotEmpty
- add first and firstOrNull

----

I also added a few utility functions to a family to easily check if it is empty or not. Also, it can be useful to get just a random single entity out of a family and do something with it. For that I introduced now `first` and `firstOrNull`.
My use case was that I check in a system if the family is not empty then I want to do something with the first entity. I did that e.g. for a camera system that updates the game camera and optionally can lock the camera to one specific entity.

Before I had to do an iteration via `forEach`. Now this can be solved via a call to `first`.

I will make the same changes to the KMP branch in the upcoming days and release a 1.4.1 version for both JVM and KMP.