### PR TITLE
#63 improve debugging

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -54,6 +54,11 @@ class Bag<T>(
         return false
     }
 
+    fun clear() {
+        values.fill(null)
+        size = 0
+    }
+
     operator fun contains(value: T): Boolean {
         for (i in 0 until size) {
             if (values[i] == value) {
@@ -199,6 +204,7 @@ private fun IntArray.med3(idxA: Int, idxB: Int, idxC: Int, comparator: EntityCom
                 else -> idxA
             }
         }
+
         bc > 0 -> idxB
         ac > 0 -> idxC
         else -> idxA

--- a/src/main/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
@@ -184,4 +184,22 @@ class BitArray(
 
         return if (bits.size == otherBits.size) true else length() == other.length()
     }
+
+    override fun toString(): String {
+        return buildString {
+            for (bitsAtWord in bits) {
+                if (bitsAtWord != 0L) {
+                    for (bit in 0 until 64) {
+                        if ((bitsAtWord and (1L shl (bit % 64))) != 0L) {
+                            append("1")
+                        } else {
+                            append("0")
+                        }
+                    }
+                } else {
+                    repeat(64) { append("0") }
+                }
+            }
+        }.trimEnd('0').ifBlank { "0" }
+    }
 }

--- a/src/main/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/component.kt
@@ -62,6 +62,16 @@ class ComponentMapper<T>(
     }
 
     /**
+     * Adds the [component] to the given [entity]. This function is only
+     * used by [World.loadSnapshot].
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun addInternal(entity: Entity, component: Any) {
+        components[entity.id] = component as T
+        listeners.forEach { it.onComponentAdded(entity, component) }
+    }
+
+    /**
      * Creates a new component if the [entity] does not have it yet. Otherwise, updates the existing component.
      * Applies the [configuration] in both cases and returns the component.
      * Notifies any registered [ComponentListener] if a new component is created.

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -220,6 +220,32 @@ class EntityService(
     }
 
     /**
+     * Updates an [entity] with the given [components].
+     * Notifies any registered [EntityListener].
+     * This function is only used by [World.loadSnapshot].
+     */
+    internal fun configureEntity(entity: Entity, components: List<Any>) {
+        val cmpMask = cmpMasks[entity.id]
+        components.forEach { cmp ->
+            val mapper = cmpService.mapper(cmp::class)
+            mapper.addInternal(entity, cmp)
+            cmpMask.set(mapper.id)
+        }
+        listeners.forEach { it.onEntityCfgChanged(entity, cmpMask) }
+    }
+
+    /**
+     * Recycles the given [entity] by adding it to the [recycledEntities]
+     * and also resetting its component mask with an empty [BitArray].
+     * This function is only used by [World.loadSnapshot].
+     */
+    internal fun recycle(entity: Entity) {
+        recycledEntities.add(entity)
+        removedEntities.set(entity.id)
+        cmpMasks[entity.id] = BitArray(64)
+    }
+
+    /**
      * Removes the given [entity] and adds it to the [recycledEntities] for future use.
      *
      * If [delayRemoval] is set then the [entity] is not removed immediately and instead will be cleaned up
@@ -249,16 +275,25 @@ class EntityService(
 
     /**
      * Removes all [entities][Entity] and adds them to the [recycledEntities] for future use.
+     * If [clearRecycled] is true then the recycled entities are cleared and the ids for newly
+     * created entities start at 0 again.
      *
      * Refer to [remove] for more details.
      */
-    fun removeAll() {
+    fun removeAll(clearRecycled: Boolean = false) {
         for (id in 0 until nextId) {
             val entity = Entity(id)
             if (removedEntities[entity.id]) {
                 continue
             }
             remove(entity)
+        }
+
+        if (clearRecycled) {
+            nextId = 0
+            recycledEntities.clear()
+            removedEntities.clearAll()
+            cmpMasks.clear()
         }
     }
 

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -276,6 +276,13 @@ class EntityService(
     }
 
     /**
+     * Returns true if and only if the [entity] not removed and is part of the [EntityService].
+     */
+    operator fun contains(entity: Entity): Boolean {
+        return entity.id in 0 until nextId && !removedEntities[entity.id]
+    }
+
+    /**
      * Clears the [delayRemoval] flag and removes [entities][Entity] which are part of the [delayedEntities].
      */
     fun cleanupDelays() {

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -311,7 +311,7 @@ class EntityService(
     }
 
     /**
-     * Returns true if and only if the [entity] not removed and is part of the [EntityService].
+     * Returns true if and only if the [entity] is not removed and is part of the [EntityService].
      */
     operator fun contains(entity: Entity): Boolean {
         return entity.id in 0 until nextId && !removedEntities[entity.id]

--- a/src/main/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/exception.kt
@@ -50,3 +50,5 @@ class FleksFamilyException(
         |noneOf: $noneOf
         |anyOf: $anyOf""".trimMargin()
 )
+
+class FleksSnapshotException(reason: String) : FleksException("Cannot load snapshot: $reason!")

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -312,9 +312,11 @@ class World internal constructor(
     /**
      * Removes all [entities][Entity] from the world. The entities will be recycled and reused for
      * future calls to [World.entity].
+     * If [clearRecycled] is true then the recycled entities are cleared and the ids for newly
+     * created entities start at 0 again.
      */
-    fun removeAll() {
-        entityService.removeAll()
+    fun removeAll(clearRecycled: Boolean = false) {
+        entityService.removeAll(clearRecycled)
     }
 
     /**
@@ -488,6 +490,47 @@ class World internal constructor(
         }
 
         return cmps
+    }
+
+    /**
+     * Loads the given [snapshot] of the world. This will first clear any existing
+     * entity of the world. After that it will load all provided entities and components.
+     * This will also notify [ComponentListener] and [FamilyListener].
+     *
+     * @throws FleksSnapshotException if a family iteration is currently in process.
+     *
+     * @throws FleksMissingNoArgsComponentConstructorException if any of the components is missing
+     * a no argument constructor.
+     */
+    fun loadSnapshot(snapshot: Map<Entity, List<Any>>) {
+        if (entityService.delayRemoval) {
+            throw FleksSnapshotException("Snapshots cannot be loaded while a family iteration is in process")
+        }
+
+        // remove any existing entity and clean up recycled ids
+        removeAll(true)
+        if (snapshot.isEmpty()) {
+            // snapshot is empty -> nothing to load
+            return
+        }
+
+        // Set next entity id to the maximum provided id + 1.
+        // All ids before that will be either created or added to the recycled
+        // ids to guarantee that the provided snapshot entity ids match the newly created ones.
+        with(entityService) {
+            val maxId = snapshot.keys.maxOf { it.id }
+            this.nextId = maxId + 1
+            repeat(maxId + 1) {
+                val entity = Entity(it)
+                this.recycle(entity)
+                val components = snapshot[entity]
+                if (components != null) {
+                    // components for entity are provided -> create it
+                    // note that the id for the entity will be the recycled id from above
+                    this.configureEntity(this.create { }, components)
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -459,8 +459,8 @@ class World internal constructor(
      * The values are a list of components that a specific entity has. If the entity
      * does not have any components then the value is an empty list.
      */
-    fun toMap(): Map<Entity, List<Any>> {
-        val result = mutableMapOf<Entity, List<Any>>()
+    fun snapshot(): Map<Entity, List<Any>> {
+        val entityCmps = mutableMapOf<Entity, List<Any>>()
 
         entityService.forEach { entity ->
             val components = mutableListOf<Any>()
@@ -468,10 +468,26 @@ class World internal constructor(
             cmpMask.forEachSetBit { cmpId ->
                 components += componentService.mapper(cmpId)[entity] as Any
             }
-            result[entity] = components
+            entityCmps[entity] = components
         }
 
-        return result
+        return entityCmps
+    }
+
+    /**
+     * Returns a list that contains all components of the given [entity] of this world.
+     * If the entity does not have any components then an empty list is returned.
+     */
+    fun snapshotOf(entity: Entity): List<Any> {
+        val cmps = mutableListOf<Any>()
+
+        if (entity in entityService) {
+            entityService.cmpMasks[entity.id].forEachSetBit { cmpId ->
+                cmps += componentService.mapper(cmpId)[entity] as Any
+            }
+        }
+
+        return cmps
     }
 
     /**

--- a/src/main/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/world.kt
@@ -454,6 +454,27 @@ class World internal constructor(
     }
 
     /**
+     * Returns a map that contains all [entities][Entity] and their components of this world.
+     * The keys of the map are the entities.
+     * The values are a list of components that a specific entity has. If the entity
+     * does not have any components then the value is an empty list.
+     */
+    fun toMap(): Map<Entity, List<Any>> {
+        val result = mutableMapOf<Entity, List<Any>>()
+
+        entityService.forEach { entity ->
+            val components = mutableListOf<Any>()
+            val cmpMask = entityService.cmpMasks[entity.id]
+            cmpMask.forEachSetBit { cmpId ->
+                components += componentService.mapper(cmpId)[entity] as Any
+            }
+            result[entity] = components
+        }
+
+        return result
+    }
+
+    /**
      * Updates all [enabled][IntervalSystem.enabled] [systems][IntervalSystem] of the world
      * using the given [deltaTime].
      */

--- a/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
@@ -283,4 +283,17 @@ internal class EntityTest {
             { assertEquals(1, listener.numCalls) }
         )
     }
+
+    @Test
+    fun `test contains entity`() {
+        val service = EntityService(32, ComponentService())
+        val e1 = service.create { }
+        val e2 = service.create { }
+        service.remove(e2)
+        val e3 = Entity(2)
+
+        assertTrue(e1 in service)
+        assertFalse(e2 in service)
+        assertFalse(e3 in service)
+    }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -686,4 +686,85 @@ internal class WorldTest {
         assertEquals(expected2, w.snapshotOf(e2))
         assertEquals(expected2, w.snapshotOf(Entity(42)))
     }
+
+    @Test
+    fun `test load empty snapshot`() {
+        val w = world { }
+        // loading snapshot will remove any existing entity
+        w.entity { }
+
+        w.loadSnapshot(emptyMap())
+
+        assertEquals(0, w.numEntities)
+    }
+
+    @Test
+    fun `test load snapshot while family iteration in process`() {
+        val w = world { }
+        val f = w.family(allOf = arrayOf(WorldTestComponent::class))
+        w.entity { add<WorldTestComponent>() }
+
+        f.forEach {
+            assertThrows<FleksSnapshotException> { w.loadSnapshot(emptyMap()) }
+        }
+    }
+
+    @Test
+    fun `test load snapshot with three entities`() {
+        val w = world {
+            injectables {
+                add("42")
+            }
+
+            components {
+                add<WorldTestComponentListener>()
+            }
+
+            systems {
+                add<WorldTestIteratingSystem>()
+            }
+        }
+        val cmpListener = w.componentService.mapper<WorldTestComponent>().listeners[0] as WorldTestComponentListener
+        val snapshot = mapOf(
+            Entity(3) to listOf(WorldTestComponent(), WorldTestComponent2()),
+            Entity(5) to listOf(WorldTestComponent()),
+            Entity(7) to listOf()
+        )
+
+        w.loadSnapshot(snapshot)
+        val actual = w.snapshot()
+        w.update(1f)
+
+        // 3 entities should be loaded
+        assertEquals(3, w.numEntities)
+        // actual snapshot after loading the test snapshot is loaded should match
+        assertEquals(snapshot.size, actual.size)
+        snapshot.forEach { (entity, expectedCmps) ->
+            val actualCmps = actual[entity]
+            assertNotNull(actualCmps)
+            assertEquals(expectedCmps.size, actualCmps.size)
+            assertTrue(expectedCmps.containsAll(actualCmps) && actualCmps.containsAll(expectedCmps))
+        }
+        // 2 out of 3 loaded entities should be part of the IteratingSystem family
+        assertEquals(2, w.system<WorldTestIteratingSystem>().numCallsEntity)
+        // 2 out of 3 loaded entities should notify the WorldTestComponentListener
+        assertEquals(2, cmpListener.numAdd)
+        assertEquals(0, cmpListener.numRemove)
+        assertEquals(3, actual.size)
+    }
+
+    @Test
+    fun `test create entity after snapshot loaded`() {
+        val w = world { }
+        val snapshot = mapOf(
+            Entity(1) to listOf<Any>()
+        )
+
+        w.loadSnapshot(snapshot)
+
+        // first created entity should be recycled Entity 0
+        assertEquals(Entity(0), w.entity())
+        // next created entity should be new Entity 2
+        assertEquals(Entity(2), w.entity())
+    }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -645,7 +645,7 @@ internal class WorldTest {
     }
 
     @Test
-    fun `test toMap`() {
+    fun `test snapshot`() {
         val w = world { }
         lateinit var cmp1: Any
         val e1 = w.entity { cmp1 = add<WorldTestComponent>() }
@@ -662,7 +662,7 @@ internal class WorldTest {
             e3 to listOf(cmp31, cmp32)
         )
 
-        val actual = w.toMap()
+        val actual = w.snapshot()
 
         assertEquals(expected.size, actual.size)
         expected.forEach { (entity, expectedCmps) ->
@@ -671,5 +671,19 @@ internal class WorldTest {
             assertEquals(expectedCmps.size, actualCmps.size)
             assertTrue(expectedCmps.containsAll(actualCmps) && actualCmps.containsAll(expectedCmps))
         }
+    }
+
+    @Test
+    fun `test snapshotOf`() {
+        val w = world { }
+        lateinit var cmp1: WorldTestComponent
+        val e1 = w.entity { cmp1 = add() }
+        val e2 = w.entity { }
+        val expected1 = listOf<Any>(cmp1)
+        val expected2 = emptyList<Any>()
+
+        assertEquals(expected1, w.snapshotOf(e1))
+        assertEquals(expected2, w.snapshotOf(e2))
+        assertEquals(expected2, w.snapshotOf(Entity(42)))
     }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -710,6 +710,20 @@ internal class WorldTest {
     }
 
     @Test
+    fun `test load snapshot with one entity`() {
+        val w = world { }
+        val entity = Entity(0)
+        val cmps = listOf(WorldTestComponent())
+        val snapshot = mapOf(entity to cmps)
+
+        w.loadSnapshot(snapshot)
+        val actual = w.snapshotOf(entity)
+
+        assertEquals(1, w.numEntities)
+        assertEquals(actual, cmps)
+    }
+
+    @Test
     fun `test load snapshot with three entities`() {
         val w = world {
             injectables {

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -643,4 +643,33 @@ internal class WorldTest {
         family.updateActiveEntities()
         assertFalse(e.id in family.entitiesBag)
     }
+
+    @Test
+    fun `test toMap`() {
+        val w = world { }
+        lateinit var cmp1: Any
+        val e1 = w.entity { cmp1 = add<WorldTestComponent>() }
+        val e2 = w.entity { }
+        lateinit var cmp31: Any
+        lateinit var cmp32: Any
+        val e3 = w.entity {
+            cmp31 = add<WorldTestComponent>()
+            cmp32 = add<WorldTestComponent2>()
+        }
+        val expected = mapOf(
+            e1 to listOf(cmp1),
+            e2 to emptyList(),
+            e3 to listOf(cmp31, cmp32)
+        )
+
+        val actual = w.toMap()
+
+        assertEquals(expected.size, actual.size)
+        expected.forEach { (entity, expectedCmps) ->
+            val actualCmps = actual[entity]
+            assertNotNull(actualCmps)
+            assertEquals(expectedCmps.size, actualCmps.size)
+            assertTrue(expectedCmps.containsAll(actualCmps) && actualCmps.containsAll(expectedCmps))
+        }
+    }
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/collection/BitArrayTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/collection/BitArrayTest.kt
@@ -183,4 +183,27 @@ internal class BitArrayTest {
         assertFalse(bits.isEmpty)
         assertTrue(bits.isNotEmpty)
     }
+
+    @Test
+    fun `test toString`() {
+        val bits0 = BitArray()
+        val bits1 = BitArray().apply { set(0) }
+        val bits2 = BitArray().apply { set(3) }
+        val bits3 = BitArray().apply { set(100) }
+        val bits4 = BitArray().apply {
+            set(3)
+            set(100)
+        }
+        val expected0 = "0"
+        val expected1 = "1"
+        val expected2 = "0001"
+        val expected3 = "0".repeat(100) + "1"
+        val expected4 = "0".repeat(3) + "1" + "0".repeat(96) + "1"
+
+        assertEquals(expected0, bits0.toString())
+        assertEquals(expected1, bits1.toString())
+        assertEquals(expected2, bits2.toString())
+        assertEquals(expected3, bits3.toString())
+        assertEquals(expected4, bits4.toString())
+    }
 }


### PR DESCRIPTION
PR for #63 

- adds `toString` for BitArray
- adds `snapshot` for World
- adds `snapshotOf` for World
- adds `loadSnapshot` for World

I am not 100% happy with the name toMap. Maybe we can come up with something better? ;)

I will also add a debug page to the wiki to explain how you can debug your entity world by explaining the connection between EntityService and ComponentService. This all gets simplified with the new toMap function.