### PR TITLE
#62 fix family noneof

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -25,6 +25,13 @@ interface EntityListener {
      * unique id. Refer to [ComponentMapper] for more details.
      */
     fun onEntityCfgChanged(entity: Entity, cmpMask: BitArray) = Unit
+
+    /**
+     * Function that gets called when an [entity][Entity] gets removed.
+     *
+     * @param entity the [entity][Entity] that gets removed.
+     */
+    fun onEntityRemoved(entity: Entity) = Unit
 }
 
 @DslMarker
@@ -236,7 +243,7 @@ class EntityService(
                 cmpService.mapper(cmpId).removeInternal(entity)
             }
             cmpMask.clearAll()
-            listeners.forEach { it.onEntityCfgChanged(entity, cmpMask) }
+            listeners.forEach { it.onEntityRemoved(entity) }
         }
     }
 

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -209,6 +209,19 @@ data class Family(
     }
 
     /**
+     * Removes the [entity] of the family and sets the [isDirty] flag if and only
+     * if the [entity] is already in the family.
+     */
+    override fun onEntityRemoved(entity: Entity) {
+        if (entities[entity.id]) {
+            // existing entity gets removed
+            isDirty = true
+            entities.clear(entity.id)
+            listeners.forEach { it.onEntityRemoved(entity) }
+        }
+    }
+
+    /**
      * Adds the given [listener] to the list of [FamilyListener].
      */
     fun addFamilyListener(listener: FamilyListener) = listeners.add(listener)

--- a/src/main/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/family.kt
@@ -219,7 +219,7 @@ data class Family(
     fun removeFamilyListener(listener: FamilyListener) = listeners.removeValue(listener)
 
     /**
-     * Returns true if an only if the given [listener] is part of the list of [FamilyListener].
+     * Returns true if and only if the given [listener] is part of the list of [FamilyListener].
      */
     operator fun contains(listener: FamilyListener) = listener in listeners
 }

--- a/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/EntityTest.kt
@@ -14,6 +14,11 @@ private class EntityTestListener : EntityListener {
         entityReceived = entity
         cmpMaskReceived = cmpMask
     }
+
+    override fun onEntityRemoved(entity: Entity) {
+        ++numCalls
+        entityReceived = entity
+    }
 }
 
 private data class EntityTestComponent(var x: Float = 0f)
@@ -154,7 +159,6 @@ internal class EntityTest {
         assertAll(
             { assertEquals(1, listener.numCalls) },
             { assertEquals(expectedEntity, listener.entityReceived) },
-            { assertFalse(listener.cmpMaskReceived[0]) },
             { assertFalse(expectedEntity in mapper) }
         )
     }

--- a/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -626,4 +626,21 @@ internal class WorldTest {
         assertContentEquals(listOf(Entity(0)), iteratedEntities)
         assertEquals(2, f.numEntities)
     }
+
+    @Test
+    fun `test entity removal with noneOf family`() {
+        // entity that gets removed has no components and is therefore
+        // part of any family that only has a noneOf configuration.
+        // However, such entities still need to be removed of those families.
+        val w = world { }
+        val family = w.family(noneOf = arrayOf(WorldTestComponent::class))
+        val e = w.entity { }
+
+        family.updateActiveEntities()
+        assertTrue(e.id in family.entitiesBag)
+
+        w.remove(e)
+        family.updateActiveEntities()
+        assertFalse(e.id in family.entitiesBag)
+    }
 }


### PR DESCRIPTION
PR for #62

I decided to go for a separate `onEntityRemoved` function for the `EntityListener` instead of a third `isRemoved` parameter for the existing `onEntityCfgChanged` function.

I think it is cleaner and should also slightly increase the entity removal performance because the check that needs to be done in a family can be simplified in this case. No need to check the entity's component mask against the family settings. We only need to check if the entity is in the family and if yes, remove it. This is a simple bit check of the entities BitArray of a family.

I also fixed a typo that I thought is already fixed before but for whatever reason it isn't :D.

I hope this is fine and doesn't break anything!