### PR TITLE
break through new Component/ComponentType approach

### DIFF
--- a/src/main/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/component.kt
@@ -6,6 +6,18 @@ import java.lang.reflect.Constructor
 import kotlin.math.max
 import kotlin.reflect.KClass
 
+open class ComponentType<C>(val id: Int = nextId++) {
+    companion object {
+        private var nextId = 0
+    }
+}
+
+interface Component<C> {
+    fun type(): ComponentType<C>
+
+    fun onRemove(entity: Entity) = Unit
+}
+
 /**
  * Interface of a component listener that gets notified when a component of a specific type
  * gets added or removed from an [entity][Entity].
@@ -65,6 +77,7 @@ class ComponentMapper<T>(
      * Adds the [component] to the given [entity]. This function is only
      * used by [World.loadSnapshot].
      */
+    @PublishedApi
     @Suppress("UNCHECKED_CAST")
     internal fun addInternal(entity: Entity, component: Any) {
         components[entity.id] = component as T

--- a/src/main/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/component.kt
@@ -14,8 +14,6 @@ open class ComponentType<C>(val id: Int = nextId++) {
 
 interface Component<C> {
     fun type(): ComponentType<C>
-
-    fun onRemove(entity: Entity) = Unit
 }
 
 /**

--- a/src/main/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/entity.kt
@@ -64,6 +64,12 @@ class EntityCreateCfg(
         cmpMask.set(mapper.id)
         return mapper.addInternal(entity, configuration)
     }
+
+    inline operator fun <reified C> Entity.plusAssign(component: Component<C>) {
+        val mapper = cmpService.mapper(component.type().id)
+        cmpMask.set(mapper.id)
+        return mapper.addInternal(this, component)
+    }
 }
 
 /**

--- a/src/main/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/main/kotlin/com/github/quillraven/fleks/system.kt
@@ -195,6 +195,10 @@ abstract class IteratingSystem(
      */
     open fun onAlphaEntity(entity: Entity, alpha: Float) = Unit
 
+    inline operator fun <reified C> Entity.get(type: ComponentType<C>): C {
+        return world.componentService.mapper(type.id)[this] as C
+    }
+
     companion object {
         private val EMPTY_COMPARATOR = object : EntityComparator {
             override fun compare(entityA: Entity, entityB: Entity): Int = 0

--- a/src/test/kotlin/com/github/quillraven/fleks/fleks2.kt
+++ b/src/test/kotlin/com/github/quillraven/fleks/fleks2.kt
@@ -1,0 +1,40 @@
+package com.github.quillraven.fleks
+
+data class Position(var x: Float = 0f, var y: Float = 0f) : Component<Position> {
+    companion object : ComponentType<Position>()
+
+    override fun type() = Position
+}
+
+class PositionComponentListener : ComponentListener<Position> {
+    override fun onComponentAdded(entity: Entity, component: Position) {
+        println("added")
+    }
+
+    override fun onComponentRemoved(entity: Entity, component: Position) = Unit
+}
+
+@AllOf([Position::class])
+class PositionSystem : IteratingSystem() {
+    override fun onTickEntity(entity: Entity) {
+        println(entity[Position])
+    }
+}
+
+fun main() {
+    val w = world {
+        components {
+            add<PositionComponentListener>()
+        }
+
+        systems {
+            add<PositionSystem>()
+        }
+    }
+
+    w.entity {
+        it += Position(2f, 3f)
+    }
+
+    w.update(1f)
+}


### PR DESCRIPTION
This is just a draft PR for potential Fleks 2.0 changes.

At the moment it is a quick breakthrough implementation of a new `Component` and `ComponentType`. That way we can remove the reflection stuff for components completely for JVM. For KMP it is no longer necessary to register a factory method for components.

Discussion continues in the "Discussions" area for Fleks ;)

example of new API:

```kotlin
// new Component interface; requires to override the type() function to return a ComponentType
data class Position(var x: Float = 0f, var y: Float = 0f) : Component<Position> {
   companion object : ComponentType<Position>()

   override fun type() = Position
}

// we can keep existing stuff of course like ComponentListener. They will still work as before
class PositionComponentListener : ComponentListener<Position> {
    override fun onComponentAdded(entity: Entity, component: Position) {
        println("added")
    }

    override fun onComponentRemoved(entity: Entity, component: Position) = Unit
}

// No need to inject ComponentMapper anymore; we can directly access components of an entity in a system like
// in this example via "entity[Position]"
@AllOf([Position::class])
class PositionSystem : IteratingSystem() {
    override fun onTickEntity(entity: Entity) {
        println(entity[Position])
    }
}

fun main() {
    val w = world {
        components {
            add<PositionComponentListener>()
        }

        systems {
            add<PositionSystem>()
        }
    }

    w.entity {
        // components are no longer created via reflection. They are directly created and added by the user
        it += Position(2f, 3f)
    }

    w.update(1f)
}
```