### PR TITLE
#76 family not updated

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,10 +1,10 @@
 # Fleks
 
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Quillraven/Fleks/blob/master/LICENSE)
-[![Maven](https://img.shields.io/badge/Maven-2.1-success.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/2.1/jar)
+[![Maven](https://img.shields.io/badge/Maven-2.1a-success.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/2.1/jar)
 
 [![Build Master](https://img.shields.io/github/workflow/status/quillraven/fleks/Build/master?event=push&label=Build%20master)](https://github.com/Quillraven/fleks/actions)
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.7.20-red.svg)](http://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.7.21-red.svg)](http://kotlinlang.org/)
 
 A **f**ast, **l**ightweight, **e**ntity component **s**ystem library written in **K**otlin.
 
@@ -69,26 +69,26 @@ To use Fleks add it as a dependency to your project:
 <dependency>
   <groupId>io.github.quillraven.fleks</groupId>
   <artifactId>Fleks</artifactId>
-  <version>2.1</version>
+  <version>2.1a</version>
 </dependency>
 ```
 
 #### Gradle (Groovy)
 
 ```kotlin
-implementation 'io.github.quillraven.fleks:Fleks:2.1'
+implementation 'io.github.quillraven.fleks:Fleks:2.1a'
 ```
 
 #### Gradle (Kotlin)
 
 ```kotlin
-implementation("io.github.quillraven.fleks:Fleks:2.1")
+implementation("io.github.quillraven.fleks:Fleks:2.1a")
 ```
 
 #### KorGE
 
 ```kotlin
-dependencyMulti("io.github.quillraven.fleks:Fleks:2.1", registerPlugin = false)
+dependencyMulti("io.github.quillraven.fleks:Fleks:2.1a", registerPlugin = false)
 ```
 
 ## API and examples

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 @file:Suppress("UNUSED_VARIABLE")
 
 plugins {
-    kotlin("multiplatform") version "1.7.20"
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.4"
+    kotlin("multiplatform") version "1.7.21"
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.5"
     id("org.jetbrains.dokka") version "1.7.20"
     `maven-publish`
     signing
 }
 
 group = "io.github.quillraven.fleks"
-version = "2.1"
+version = "2.1a"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
@@ -66,7 +66,7 @@ kotlin {
         val jvmBenchmarks by getting {
             dependsOn(commonMain)
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.4")
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.5")
                 implementation("com.badlogicgames.ashley:ashley:1.7.4")
                 implementation("net.onedaybeard.artemis:artemis-odb:2.3.0")
             }


### PR DESCRIPTION
Fixes a bug that families did not get updated properly when used in a nested way (#76).
I still need to do the final tests on my PC with my projects including a performance run. I hope adding an additional 'isIterating' field isn't that critical ;)

Also, updated Kotlin from 1.7.20 to 1.7.21 and kotlinx.benchmark to 0.4.5.

@ernespn: can you try this version in your project as well please? Just check out this branch, add "-SNAPSHOT" to the version in the gradle file and execute the publishToMavenLocal task to create version 2.1a-SNAPSHOT on your computer.

If you need further  help setting this up please let me know.

And thank you for reporting this issue!

