### PR TITLE
Add `get` operator function to `EntityBag`

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
@@ -248,6 +248,13 @@ interface EntityBag {
     fun forEachIndexed(action: (index: Int, Entity) -> Unit)
 
     /**
+     * Returns the [entity][Entity] of the given [index].
+     *
+     * @throws [IndexOutOfBoundsException] if [index] is less than zero or greater equal [size].
+     */
+    operator fun get(index: Int): Entity
+
+    /**
      * Groups [entities][Entity] by the key returned by the given [keySelector] function
      * applied to each [entity][Entity] and returns a map where each group key is associated with an [EntityBag]
      * of corresponding [entities][Entity].
@@ -392,16 +399,6 @@ class MutableEntityBag(
                 return
             }
         }
-    }
-
-    /**
-     * Returns the [entity][Entity] of the given [index].
-     *
-     * @throws [IndexOutOfBoundsException] if [index] is less than zero or greater equal [size].
-     */
-    operator fun get(index: Int): Entity {
-        if (index < 0 || index >= size) throw IndexOutOfBoundsException("$index is not valid for bag of size $size")
-        return values[index]
     }
 
     /**
@@ -863,6 +860,16 @@ class MutableEntityBag(
             result.getOrPut(key) { MutableEntityBag() } += entity
         }
         return result
+    }
+
+    /**
+     * Returns the [entity][Entity] of the given [index].
+     *
+     * @throws [IndexOutOfBoundsException] if [index] is less than zero or greater equal [size].
+     */
+    override operator fun get(index: Int): Entity {
+        if (index < 0 || index >= size) throw IndexOutOfBoundsException("$index is not valid for bag of size $size")
+        return values[index]
     }
 
     /**

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityBagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityBagTest.kt
@@ -179,6 +179,7 @@ class EntityBagTest {
     fun cannotGetValueOfOutOfBoundsIndex() {
         val bag = MutableEntityBag(2)
 
+        assertFailsWith<IndexOutOfBoundsException> { bag[-1] }
         assertFailsWith<IndexOutOfBoundsException> { bag[2] }
     }
 


### PR DESCRIPTION
Also add unit test to assert that `get` throws an `IndexOutOfBoundsException` when its `index` parameter is negative.

Fixes issue #78.

No worries if this change is undesired! Putting the pull request together only took a few minutes - just hoping to save you some time if it's a change you do want.

I moved the `get` function further down in `MutableEntityBag`. It seemed like the class layout included functions specific to `MutableEntityBag` first, followed by the `EntityBag` interface functions in alphabetical order.