### PR TITLE
Networking functionality ideas

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -531,15 +531,15 @@ class World internal constructor(
         if (entity !in entityService) {
             // entity not part of service yet -> create it
             if (entity.id >= entityService.nextId) {
-                // adjust ID for next entity to be created
-                entityService.nextId = entity.id + 1
-
                 // entity with given id was never created before -> create all missing entities ...
                 repeat(entity.id - entityService.nextId + 1) {
                     entityService.recycle(Entity(entityService.nextId + it))
                 }
                 // ... and then create the entity to guarantee that it has the correct ID.
                 // The entity is at the end of the recycled list.
+
+                // adjust ID for future entities to be created
+                entityService.nextId = entity.id + 1
                 entityService.create { }
             } else {
                 // entity with given id was already created before and is part of the recycled entities


### PR DESCRIPTION
PR for #80 

I added a new `loadSnapshotOf` function to the world which allows to set components for a specific entity. If the entity already exists, then its components get replaced with the new ones. If the entity does not exist, it will be created before setting its components.

@Gidroshvandel, @jobe-m : I'd like to continue the discussion in this PR please. This is not final yet. I suggest that we wait for the feedback of @Gidroshvandel and his network game before merging anything of this branch.

Imo this function could still be useful for Fleks in general but let's see what kind of other things we might add for better networking support ;)