### PR TITLE
Add kotlinx serialization support to fleks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("multiplatform") version "1.7.21"
     id("org.jetbrains.kotlinx.benchmark") version "0.4.5"
     id("org.jetbrains.dokka") version "1.7.20"
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.4.0"
     `maven-publish`
     signing
 }
@@ -55,7 +56,11 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting { }
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
+            }
+        }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -1,12 +1,14 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.*
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /**
  * An entity of a [world][World]. It represents a unique id.
  */
 @JvmInline
+@Serializable
 value class Entity(val id: Int)
 
 /**


### PR DESCRIPTION
To be able to serialize world snapshot of fleks the kotlinx serializer
needs to know "how" to serialize Entity value class. Thus, it would
be nice to add @Serializable annotation from kotlinx.serialization
directly to the Entity class declaration. With that it is possible to serialize
the world snapshot (or snapshotOf) in a kotlin multiplatform game that
uses kotlinx.serialization.

In korge-fleks there are now unit tests which check serialization of
components. :-)
This check currently fails to to the missing addition in fleks: 
https://github.com/korlibs/korge-fleks/pull/4

No need to create directly new release in Maven. I can use the commit
hash or a local pre-release tag with KorGE kproject
<https://github.com/korlibs/korge-fleks/blob/main/example/libs/fleks.kproject.yml>.