### PR TITLE
add kotlin serialization dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import kotlinx.benchmark.gradle.KotlinJvmBenchmarkTarget
 
 plugins {
     kotlin("multiplatform") version "1.8.21"
+    kotlin("plugin.serialization") version "1.8.21"
     id("org.jetbrains.kotlinx.benchmark") version "0.4.8"
     id("org.jetbrains.dokka") version "1.8.10"
     `maven-publish`
@@ -50,7 +51,11 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+            }
+        }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -1,12 +1,14 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.*
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /**
  * An entity of a [world][World]. It represents a unique id.
  */
 @JvmInline
+@Serializable
 value class Entity(val id: Int)
 
 /**


### PR DESCRIPTION
As discussed in #87, kotlinx serialization is the standard for multiplatform serialization. I checked the size difference of built maven files and seems like it is at most 3kb (JVM). For other platforms it is even smaller. That's why I don't see an issue in adding this dependency.

This is the newest version (1.5.1) which required a slightly different gradle setup than the previous 1.4.0 version. Can you try this version please @jobe-m and let me know if it is still working for you?

Also, this is just part 1 for #87. I still want to provide an option to users to use their own "entity id creation/deletion" provider, if necessary. This will be the second part which I also want to include in upcoming 2.4 version.