### PR TITLE
add new 'EntityProvider' interface and configuration

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -181,6 +181,12 @@ class EntityUpdateContext(
 interface EntityProvider {
 
     /**
+     * Reference to the [World] of the [EntityProvider].
+     * It is needed for the [forEach] implementation.
+     */
+    val world: World
+
+    /**
      * Returns the total amount of active [entities][Entity].
      */
     fun numEntities(): Int
@@ -224,8 +230,7 @@ interface EntityProvider {
  * The first [entity][Entity] starts with ID zero.
  */
 class DefaultEntityProvider(
-    @PublishedApi
-    internal val world: World,
+    override val world: World,
     initialEntityCapacity: Int
 ) : EntityProvider {
 

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/exception.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/exception.kt
@@ -30,9 +30,6 @@ class FleksNoSuchInjectableException(name: String) :
 class FleksHookAlreadyAddedException(hookType: String, objType: String) :
     FleksException("$hookType for $objType already available!")
 
-class FleksWrongConfigurationOrderException :
-    FleksException("Component hooks and family hooks must be defined BEFORE any system. The 'systems' block must come last in a WorldConfiguration.")
-
 class FleksWrongConfigurationUsageException :
     FleksException(
         "The global functions 'inject' and 'family' must be used inside a WorldConfiguration scope." +

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -200,6 +200,10 @@ class WorldConfiguration(@PublishedApi internal val world: World) {
         world.setEntityRemoveHook(hook)
     }
 
+    /**
+     * Sets the [EntityProvider] for the [EntityService] by calling the [factory] function
+     * within the context of a [World]. Per default the [DefaultEntityProvider] is used.
+     */
     fun entityProvider(factory: World.() -> EntityProvider) {
         world.entityService.entityProvider = world.run(factory)
     }
@@ -250,7 +254,7 @@ class World internal constructor(
         private set
 
     @PublishedApi
-    internal var entityService = EntityService(this, entityCapacity)
+    internal val entityService = EntityService(this, entityCapacity)
 
     /**
      * List of all [families][Family] of the world that are created either via

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -55,8 +55,6 @@ class InjectableConfiguration(private val world: World) {
 class ComponentConfiguration(
     @PublishedApi
     internal val world: World,
-    @PublishedApi
-    internal val systems: List<IntervalSystem>,
 ) {
 
     /**
@@ -67,10 +65,6 @@ class ComponentConfiguration(
         type: ComponentType<T>,
         noinline hook: ComponentHook<T>
     ) {
-        if (systems.isNotEmpty()) {
-            throw FleksWrongConfigurationOrderException()
-        }
-
         world.setComponentAddHook(type, hook)
     }
 
@@ -82,10 +76,6 @@ class ComponentConfiguration(
         type: ComponentType<T>,
         noinline hook: ComponentHook<T>
     ) {
-        if (systems.isNotEmpty()) {
-            throw FleksWrongConfigurationOrderException()
-        }
-
         world.setComponentRemoveHook(type, hook)
     }
 }
@@ -95,7 +85,7 @@ class ComponentConfiguration(
  */
 @WorldCfgMarker
 class SystemConfiguration(
-    private val systems: MutableList<IntervalSystem> = mutableListOf()
+    internal val systems: MutableList<IntervalSystem> = mutableListOf()
 ) {
     /**
      * Adds the [system] to the [world][World].
@@ -118,8 +108,6 @@ class SystemConfiguration(
 class FamilyConfiguration(
     @PublishedApi
     internal val world: World,
-    @PublishedApi
-    internal val systems: List<IntervalSystem>,
 ) {
 
     /**
@@ -130,10 +118,6 @@ class FamilyConfiguration(
         family: Family,
         hook: FamilyHook
     ) {
-        if (systems.isNotEmpty()) {
-            throw FleksWrongConfigurationOrderException()
-        }
-
         if (family.addHook != null) {
             throw FleksHookAlreadyAddedException("addHook", "Family $family")
         }
@@ -148,10 +132,6 @@ class FamilyConfiguration(
         family: Family,
         hook: FamilyHook
     ) {
-        if (systems.isNotEmpty()) {
-            throw FleksWrongConfigurationOrderException()
-        }
-
         if (family.removeHook != null) {
             throw FleksHookAlreadyAddedException("removeHook", "Family $family")
         }
@@ -168,19 +148,26 @@ class FamilyConfiguration(
 @WorldCfgMarker
 class WorldConfiguration(@PublishedApi internal val world: World) {
 
-    internal val systems = mutableListOf<IntervalSystem>()
-    private val injectableCfg = InjectableConfiguration(world)
-    private val compCfg = ComponentConfiguration(world, systems)
-    private val familyCfg = FamilyConfiguration(world, systems)
-    private val systemCfg = SystemConfiguration(systems)
+    private var injectableCfg: (InjectableConfiguration.() -> Unit)? = null
+    private var compCfg: (ComponentConfiguration.() -> Unit)? = null
+    private var familyCfg: (FamilyConfiguration.() -> Unit)? = null
+    private var systemCfg: (SystemConfiguration.() -> Unit)? = null
 
-    fun injectables(cfg: InjectableConfiguration.() -> Unit) = injectableCfg.run(cfg)
+    fun injectables(cfg: InjectableConfiguration.() -> Unit) {
+        injectableCfg = cfg
+    }
 
-    fun components(cfg: ComponentConfiguration.() -> Unit) = compCfg.run(cfg)
+    fun components(cfg: ComponentConfiguration.() -> Unit) {
+        compCfg = cfg
+    }
 
-    fun families(cfg: FamilyConfiguration.() -> Unit) = familyCfg.run(cfg)
+    fun families(cfg: FamilyConfiguration.() -> Unit) {
+        familyCfg = cfg
+    }
 
-    fun systems(cfg: SystemConfiguration.() -> Unit) = systemCfg.run(cfg)
+    fun systems(cfg: SystemConfiguration.() -> Unit) {
+        systemCfg = cfg
+    }
 
     /**
      * Sets the add entity [hook][EntityService.addHook].
@@ -207,6 +194,18 @@ class WorldConfiguration(@PublishedApi internal val world: World) {
     fun entityProvider(factory: World.() -> EntityProvider) {
         world.entityService.entityProvider = world.run(factory)
     }
+
+    fun configure() {
+        injectableCfg?.invoke(InjectableConfiguration(world))
+        compCfg?.invoke(ComponentConfiguration(world))
+        familyCfg?.invoke(FamilyConfiguration(world))
+        SystemConfiguration().also {
+            systemCfg?.invoke(it)
+            // assign world systems afterward to resize the systems array only once to the correct size
+            // instead of resizing every time a system gets added to the configuration
+            world.systems = it.systems.toTypedArray()
+        }
+    }
 }
 
 /**
@@ -224,10 +223,7 @@ fun configureWorld(entityCapacity: Int = 512, cfg: WorldConfiguration.() -> Unit
     CURRENT_WORLD = newWorld
 
     try {
-        val worldCfg = WorldConfiguration(newWorld).apply(cfg)
-        // assign world systems afterward to resize the systems array only once to the correct size
-        // instead of resizing every time a system gets added to the configuration
-        newWorld.systems = worldCfg.systems.toTypedArray()
+        WorldConfiguration(newWorld).apply(cfg).configure()
     } finally {
         CURRENT_WORLD = null
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTest.kt
@@ -57,7 +57,6 @@ internal class EntityTest {
 
         testEntityService.removeAll()
 
-        assertEquals(2, testEntityService.recycledEntities.size)
         assertEquals(0, testEntityService.numEntities)
     }
 
@@ -69,7 +68,6 @@ internal class EntityTest {
 
         testEntityService.removeAll()
 
-        assertEquals(2, testEntityService.recycledEntities.size)
         assertEquals(0, testEntityService.numEntities)
     }
 
@@ -82,7 +80,6 @@ internal class EntityTest {
         testEntityService.removeAll()
 
         assertTrue(testEntityService.delayRemoval)
-        assertEquals(0, testEntityService.recycledEntities.size)
         assertEquals(2, testEntityService.numEntities)
     }
 
@@ -103,7 +100,6 @@ internal class EntityTest {
 
         testEntityService -= entity
 
-        assertEquals(0, testEntityService.recycledEntities.size)
         assertEquals(1, testEntityService.numEntities)
     }
 
@@ -118,7 +114,6 @@ internal class EntityTest {
         testEntityService.cleanupDelays()
 
         assertFalse(testEntityService.delayRemoval)
-        assertEquals(1, testEntityService.recycledEntities.size)
         assertEquals(0, testEntityService.numEntities)
     }
 
@@ -129,7 +124,6 @@ internal class EntityTest {
         testEntityService -= entity
         testEntityService -= entity
 
-        assertEquals(1, testEntityService.recycledEntities.size)
         assertEquals(0, testEntityService.numEntities)
     }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/FamilyTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/FamilyTest.kt
@@ -197,13 +197,13 @@ internal class FamilyTest {
             ++numOuterIterations
 
             // check that inner iteration is not clearing the delayRemoval flag
-            assertTrue { this.entityService.delayRemoval }
+            assertTrue(this.entityService.delayRemoval)
             // check that inner iteration is not cleaning up the delayed removals
-            assertEquals(0, this.entityService.removedEntities.length())
+            assertTrue(e1 in this.entityService)
         }
 
-        assertFalse { f1.entityService.delayRemoval }
-        assertEquals(1, f1.entityService.removedEntities.length())
+        assertFalse(f1.entityService.delayRemoval)
+        assertFalse(e1 in f1.entityService)
         assertEquals(2, numOuterIterations)
         assertEquals(4, numInnerIterations)
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -706,8 +706,6 @@ internal class WorldTest {
         w.loadSnapshotOf(entity, components)
 
         assertEquals(1, w.numEntities)
-        assertEquals(1, w.entityService.nextId)
-        assertEquals(0, w.entityService.recycledEntities.size)
         assertTrue { with(w) { entity has WorldTestComponent } }
         assertTrue { entity in family }
     }
@@ -723,8 +721,6 @@ internal class WorldTest {
         w.loadSnapshotOf(entity, components)
 
         assertEquals(1, w.numEntities)
-        assertEquals(2, w.entityService.nextId)
-        assertEquals(1, w.entityService.recycledEntities.size)
         assertTrue { with(w) { entity has WorldTestComponent } }
         assertTrue { entity in family }
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -788,61 +788,6 @@ internal class WorldTest {
     }
 
     @Test
-    fun systemsMustBeSpecifiedLast() {
-        // component add hook defined after system
-        assertFailsWith<FleksWrongConfigurationOrderException> {
-            configureWorld {
-                systems {
-                    add(WorldTestInitSystem())
-                }
-
-                components {
-                    onAdd(WorldTestComponent) { _, _ -> }
-                }
-            }
-        }
-
-        // component remove hook defined after system
-        assertFailsWith<FleksWrongConfigurationOrderException> {
-            configureWorld {
-                systems {
-                    add(WorldTestInitSystem())
-                }
-
-                components {
-                    onRemove(WorldTestComponent) { _, _ -> }
-                }
-            }
-        }
-
-        // family add hook defined after system
-        assertFailsWith<FleksWrongConfigurationOrderException> {
-            configureWorld {
-                systems {
-                    add(WorldTestInitSystem())
-                }
-
-                families {
-                    onAdd(family { all(WorldTestComponent) }) { }
-                }
-            }
-        }
-
-        // family remove hook defined after system
-        assertFailsWith<FleksWrongConfigurationOrderException> {
-            configureWorld {
-                systems {
-                    add(WorldTestInitSystem())
-                }
-
-                families {
-                    onRemove(family { all(WorldTestComponent) }) { }
-                }
-            }
-        }
-    }
-
-    @Test
     fun globalWorldFunctionsMustBeUsedWithinConfigurationScope() {
         // calls BEFORE configuration block
         assertFailsWith<FleksWrongConfigurationUsageException> {
@@ -953,11 +898,11 @@ internal class WorldTest {
     @Test
     fun testCustomEntityProvider() {
         val world = configureWorld {
-            entityProvider { WorldEntityProvider(this) }
-
             systems {
                 add(WorldTestInitSystem())
             }
+
+            entityProvider { WorldEntityProvider(this) }
         }
 
         assertEquals(1, world.numEntities)


### PR DESCRIPTION
This is a "quick&dirt" implementation of extracting the entity creation/removal of the `EntityService`. That change allows users to provide their own creation logic and adds additional flexibility (part 2 of #87).

Per default, it is still using the normal Fleks entity recycling implementation.

I created a new interface called `EntityProvider` (up for discussion):
```kotlin
interface EntityProvider {
    fun numEntities(): Int

    fun create(): Entity

    fun create(id: Int): Entity

    operator fun minusAssign(entity: Entity)

    operator fun contains(entity: Entity): Boolean

    fun reset()

    fun forEach(action: World.(Entity) -> Unit)
}
```

You can pass your own provider in the configuration with the new `entityProvider` function which calls factory method that takes a `world` instance.

I am personally not sure if this helps the guys who had some questions regarding network games. I never needed such a thing in my own games but that doesn't mean that it can't be useful to others ;)

Tests and comments are currently missing. I just want to get some feedback, if we should add this change or if we leave it as it is. What do you guys think?
@jobe-m @Gidroshvandel