### PR TITLE
update `EntityComparator` to be a functional interface that extends `Comparator<Entity>`

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityCompare.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityCompare.kt
@@ -4,34 +4,27 @@ import com.github.quillraven.fleks.*
 import kotlin.math.min
 
 /**
- * Sorting of int[] logic taken from: https://github.com/karussell/fastutil/blob/master/src/it/unimi/dsi/fastutil/ints/IntArrays.java
+ * Sorting of `int[]` logic taken from: https://github.com/karussell/fastutil/blob/master/src/it/unimi/dsi/fastutil/ints/IntArrays.java
  */
-interface EntityComparator {
-    fun compare(entityA: Entity, entityB: Entity): Int
-}
+fun interface EntityComparator : Comparator<Entity>
 
 fun compareEntity(
     world: World = World.CURRENT_WORLD ?: throw FleksWrongConfigurationUsageException(),
     compareFun: World.(Entity, Entity) -> Int,
 ): EntityComparator {
-    return object : EntityComparator {
-        override fun compare(entityA: Entity, entityB: Entity): Int {
-            return compareFun(world, entityA, entityB)
-        }
-    }
+    return EntityComparator { entityA, entityB -> compareFun(world, entityA, entityB) }
 }
 
 inline fun <reified T> compareEntityBy(
     componentType: ComponentType<T>,
     world: World = World.CURRENT_WORLD ?: throw FleksWrongConfigurationUsageException(),
-): EntityComparator where T : Component<*>, T : Comparable<*> {
+): EntityComparator where T : Component<T>, T : Comparable<T> {
     return object : EntityComparator {
         private val holder = world.componentService.holder(componentType)
 
-        @Suppress("UNCHECKED_CAST")
-        override fun compare(entityA: Entity, entityB: Entity): Int {
-            val valA: Comparable<T> = holder[entityA] as Comparable<T>
-            val valB = holder[entityB]
+        override fun compare(a: Entity, b: Entity): Int {
+            val valA = holder[a]
+            val valB = holder[b]
             return valA.compareTo(valB)
         }
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityCompare.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityCompare.kt
@@ -6,7 +6,7 @@ import kotlin.math.min
 /**
  * Sorting of `int[]` logic taken from: https://github.com/karussell/fastutil/blob/master/src/it/unimi/dsi/fastutil/ints/IntArrays.java
  */
-fun interface EntityComparator : Comparator<Entity>
+typealias EntityComparator = Comparator<Entity>
 
 fun compareEntity(
     world: World = World.CURRENT_WORLD ?: throw FleksWrongConfigurationUsageException(),

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -177,8 +177,6 @@ abstract class IteratingSystem(
     open fun onAlphaEntity(entity: Entity, alpha: Float) = Unit
 
     companion object {
-        private val EMPTY_COMPARATOR = object : EntityComparator {
-            override fun compare(entityA: Entity, entityB: Entity): Int = 0
-        }
+        private val EMPTY_COMPARATOR = EntityComparator { _, _ -> 0 }
     }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityComparatorTests.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityComparatorTests.kt
@@ -1,0 +1,35 @@
+package com.github.quillraven.fleks.collection
+
+import com.github.quillraven.fleks.Entity
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+internal class EntityComparatorTests {
+
+    /** verify that [EntityComparator] extends [Comparator] and can be used to sort normal collections */
+    @Test
+    fun useEntityComparatorToSortRegularList() {
+
+        // create entities, with IDs descending from 10 to 1
+        val entities = List(10) { Entity(10 - it) }
+
+        val sorted = entities.sortedWith(EntityComparator { a, b -> a.id.compareTo(b.id) })
+
+        assertContentEquals(
+            message = "Expect entities are sorted by ascending ID, from 1 to 10",
+            expected = listOf(
+                Entity(1),
+                Entity(2),
+                Entity(3),
+                Entity(4),
+                Entity(5),
+                Entity(6),
+                Entity(7),
+                Entity(8),
+                Entity(9),
+                Entity(10),
+            ),
+            actual = sorted,
+        )
+    }
+}


### PR DESCRIPTION
update [`EntityComparator`](https://github.com/Quillraven/Fleks/blob/2b1a56d95f97c0d366c91fa3c6a495f24d656c24/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityCompare.kt#L6-L11) to be a functional interface that extends [`Comparator<Entity>`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-comparator/)

Using a functional interface means defining a new instance is shorter, and extending `Comparator<>` helps interoperability with the standard library (as demonstrated in `EntityComparatorTests#useEntityComparatorToSortRegularList()`).

In order to avoid the warning `The corresponding parameter in the supertype 'Comparator' is named 'a'. This may cause problems when calling this function with named arguments.` I renamed the parameters to match those in `Comparator<>`

Also, fix `UNCHECKED_CAST` in [`compareEntityBy()`](https://github.com/Quillraven/Fleks/blob/2b1a56d95f97c0d366c91fa3c6a495f24d656c24/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityCompare.kt#L24-L38) by adding more type restrictions
