### PR TITLE
Component lifecycle methods

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -53,6 +53,16 @@ interface Component<T> {
      * Returns the [ComponentType] of a [Component].
      */
     fun type(): ComponentType<T>
+
+    /**
+     * Lifecycle method that gets called whenever a [component][Component] gets set for an [entity][Entity].
+     */
+    fun World.onAddComponent() = Unit
+
+    /**
+     * Lifecycle method that gets called whenever a [component][Component] gets removed from an [entity][Entity].
+     */
+    fun World.onRemoveComponent() = Unit
 }
 
 /**

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -111,14 +111,20 @@ class ComponentsHolder<T : Component<*>>(
 
         // check if removeHook needs to be called
         components[entity.id]?.let { existingCmp ->
-            // assign current component to null in order for 'contains' calls inside the hook
-            // to correctly return false
+            // assign current component to null in order for 'contains' calls inside the lifecycle
+            // method to correctly return false
             components[entity.id] = null
+            existingCmp.run {
+                world.onRemoveComponent()
+            }
             removeHook?.invoke(world, entity, existingCmp)
         }
 
-        // set component and call addHook if necessary
+        // set component and call lifecycle method
         components[entity.id] = component
+        component.run {
+            world.onAddComponent()
+        }
         addHook?.invoke(world, entity, component)
     }
 
@@ -132,10 +138,11 @@ class ComponentsHolder<T : Component<*>>(
         if (entity.id < 0 || entity.id >= components.size) throw IndexOutOfBoundsException("$entity.id is not valid for components of size ${components.size}")
 
         val existingCmp = components[entity.id]
-        // assign null before running the removeHook in order for 'contains' calls to correctly return false
+        // assign null before running the lifecycle method in order for 'contains' calls to correctly return false
         components[entity.id] = null
-        if (existingCmp != null) {
+        existingCmp?.run {
             removeHook?.invoke(world, entity, existingCmp)
+            world.onRemoveComponent()
         }
     }
 

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -18,7 +18,7 @@ value class Entity(val id: Int)
 typealias EntityHook = World.(Entity) -> Unit
 
 /**
- * A class for basic [Entity] extension functions within an add/remove hook of a [Component], [Family],
+ * A class for basic [Entity] extension functions within a [Family],
  * [IntervalSystem], [World] or [compareEntity].
  */
 abstract class EntityComponentContext(
@@ -92,12 +92,12 @@ open class EntityCreateContext(
     /**
      * Adds the [component] to the [entity][Entity].
      *
-     * If a component [addHook][ComponentsHolder.addHook] is defined then it
+     * The [onAddComponent][Component.onAddComponent] lifecycle method
      * gets called after the [component] is assigned to the [entity][Entity].
      *
-     * If a component [removeHook][ComponentsHolder.removeHook] is defined and the [entity][Entity]
-     * already had such a [component] then it gets called with the previous assigned component before
-     * the [addHook][ComponentsHolder.addHook] is called.
+     * If the [entity][Entity] already had such a [component] then the [onRemoveComponent][Component.onRemoveComponent]
+     * lifecycle method gets called on the previously assigned component before the [onAddComponent][Component.onAddComponent]
+     * lifecycle method is called on the new component.
      */
     inline operator fun <reified T : Component<T>> Entity.plusAssign(component: T) {
         val compType: ComponentType<T> = component.type()
@@ -111,12 +111,12 @@ open class EntityCreateContext(
      * in exceptional cases.
      * It is preferred to use the [plusAssign] function whenever possible to have type-safety.
      *
-     * If a component [addHook][ComponentsHolder.addHook] is defined then it
-     * gets called after the component is assigned to the [entity][Entity].
+     * The [onAddComponent][Component.onAddComponent] lifecycle method
+     * gets called after each component is assigned to the [entity][Entity].
      *
-     * If a component [removeHook][ComponentsHolder.removeHook] is defined and the [entity][Entity]
-     * already had such a component then it gets called with the previous assigned component before
-     * the [addHook][ComponentsHolder.addHook] is called.
+     * If the [entity][Entity] already has such a component then the [onRemoveComponent][Component.onRemoveComponent]
+     * lifecycle method gets called on the previously assigned component before the [onAddComponent][Component.onAddComponent]
+     * lifecycle method is called on the new component.
      */
     operator fun Entity.plusAssign(components: List<Component<*>>) {
         components.forEach { cmp ->
@@ -139,8 +139,7 @@ class EntityUpdateContext(
     /**
      * Removes a [component][Component] of the given [type] from the [entity][Entity].
      *
-     * If a component [removeHook][ComponentsHolder.removeHook] is defined then it gets called
-     * if the [entity][Entity] has such a component.
+     * Calls the [onRemoveComponent][Component.onRemoveComponent] lifecycle method on the component being removed.
      *
      * @throws [IndexOutOfBoundsException] if the id of the [entity][Entity] exceeds the internal components' capacity.
      * This can only happen when the [entity][Entity] never had such a component.

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -184,39 +184,6 @@ internal class ComponentTest {
     }
 
     @Test
-    fun addComponentWithComponentListenerWhenComponentAlreadyPresent() {
-        var numAddCalls = 0
-        var numRemoveCalls = 0
-        val expectedEntity = Entity(1)
-        val expectedComp1 = ComponentTestComponent()
-        val expectedComp2 = ComponentTestComponent()
-
-        val onAdd: ComponentHook<ComponentTestComponent> = { entity, component ->
-            assertSame(testWorld, this)
-            assertEquals(expectedEntity, entity)
-            assertTrue { expectedComp1 === component || expectedComp2 === component }
-            numAddCalls++
-        }
-
-        val onRemove: ComponentHook<ComponentTestComponent> = { entity, component ->
-            assertSame(testWorld, this)
-            assertEquals(expectedEntity, entity)
-            assertSame(expectedComp1, component)
-            numRemoveCalls++
-        }
-
-        testHolder.addHook = onAdd
-        testHolder.removeHook = onRemove
-
-        testHolder[expectedEntity] = expectedComp1
-        // this should trigger onRemove of the first component
-        testHolder[expectedEntity] = expectedComp2
-
-        assertEquals(2, numAddCalls)
-        assertEquals(1, numRemoveCalls)
-    }
-
-    @Test
     fun cannotRemoveNonExistingEntityFromHolderWithInsufficientCapacity() {
         val holder = testService.holder(ComponentTestComponent)
         val entity = Entity(10_000)

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -21,6 +21,26 @@ internal class ComponentTest {
         }
     }
 
+    private data class ComponentTestWithLifecycleComponent(
+        val expectedWorld: World,
+        var numAddCalls: Int = 0,
+        var numRemoveCalls: Int = 0
+    ) : Component<ComponentTestWithLifecycleComponent> {
+        override fun type() = ComponentTestWithLifecycleComponent
+
+        override fun World.onAddComponent() {
+            assertEquals(expectedWorld, this)
+            numAddCalls++
+        }
+
+        override fun World.onRemoveComponent() {
+            assertEquals(expectedWorld, this)
+            numRemoveCalls++
+        }
+
+        companion object : ComponentType<ComponentTestWithLifecycleComponent>()
+    }
+
     private val testWorld = configureWorld { }
     private val testService = ComponentService().also { it.world = testWorld }
     private val testHolder = testService.holder(ComponentTestComponent)
@@ -127,33 +147,40 @@ internal class ComponentTest {
     }
 
     @Test
-    fun addComponentWithHook() {
-        var numAddCalls = 0
-        var numRemoveCalls = 0
+    fun addAndRemoveComponentWithLifecycleMethod() {
         val expectedEntity = Entity(1)
-        val expectedComp = ComponentTestComponent()
+        val expectedComp = ComponentTestWithLifecycleComponent(testWorld)
 
-        val onAdd: ComponentHook<ComponentTestComponent> = { entity, component ->
-            assertEquals(testWorld, this)
-            assertEquals(expectedEntity, entity)
-            assertEquals(expectedComp, component)
-            numAddCalls++
-        }
+        val testHolderForLifecycleComponent = testService.holder(ComponentTestWithLifecycleComponent)
 
-        val onRemove: ComponentHook<ComponentTestComponent> = { entity, component ->
-            assertEquals(testWorld, this)
-            assertEquals(expectedEntity, entity)
-            assertEquals(expectedComp, component)
-            numRemoveCalls++
-        }
+        assertEquals(0, expectedComp.numAddCalls)
+        assertEquals(0, expectedComp.numRemoveCalls)
+        testHolderForLifecycleComponent[expectedEntity] = expectedComp
+        assertEquals(1, expectedComp.numAddCalls)
+        assertEquals(0, expectedComp.numRemoveCalls)
+        testHolderForLifecycleComponent -= expectedEntity
+        assertEquals(1, expectedComp.numAddCalls)
+        assertEquals(1, expectedComp.numRemoveCalls)
+    }
 
-        testHolder.addHook = onAdd
-        testHolder.removeHook = onRemove
+    @Test
+    fun addAndReplaceComponentWithLifecycleMethod() {
+        val expectedEntity = Entity(1)
+        val expectedComp1 = ComponentTestWithLifecycleComponent(testWorld)
+        val expectedComp2 = ComponentTestWithLifecycleComponent(testWorld)
 
-        testHolder[expectedEntity] = expectedComp
+        val testHolderForLifecycleComponent = testService.holder(ComponentTestWithLifecycleComponent)
 
-        assertEquals(1, numAddCalls)
-        assertEquals(0, numRemoveCalls)
+        testHolderForLifecycleComponent[expectedEntity] = expectedComp1
+        assertEquals(1, expectedComp1.numAddCalls)
+        assertEquals(0, expectedComp1.numRemoveCalls)
+
+        // Should trigger onRemoveComponent on expectedComp1
+        testHolderForLifecycleComponent[expectedEntity] = expectedComp2
+        assertEquals(1, expectedComp1.numAddCalls)
+        assertEquals(1, expectedComp1.numRemoveCalls)
+        assertEquals(1, expectedComp2.numAddCalls)
+        assertEquals(0, expectedComp2.numRemoveCalls)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -58,13 +58,9 @@ private class WorldTestIteratingSystem(
     }
 }
 
-private class WorldTestInitSystem(
-    onCreateComponent: (WorldTestComponent) -> Unit = {}
-) : IteratingSystem(family { all(WorldTestComponent) }) {
+private class WorldTestInitSystem: IteratingSystem(family { all(WorldTestComponent) }) {
     init {
-        val comp = WorldTestComponent()
-        onCreateComponent(comp)
-        world.entity { it += comp }
+        world.entity { it += WorldTestComponent() }
     }
 
     override fun onTickEntity(entity: Entity) = Unit
@@ -448,15 +444,19 @@ internal class WorldTest {
 
     @Test
     fun notifyComponentHooksDuringSystemCreation() {
-        var component: WorldTestComponent? = null
-        configureWorld {
+        val w = configureWorld {
             systems {
-                add(WorldTestInitSystem { component = it })
+                add(WorldTestInitSystem())
             }
         }
 
-        assertEquals(1, component?.numAddCalls)
-        assertEquals(0, component?.numRemoveCalls)
+        val testComp = with(w) {
+            val entity = w.family { all(WorldTestComponent) }.first()
+            return@with entity[WorldTestComponent]
+        }
+
+        assertEquals(1, testComp.numAddCalls)
+        assertEquals(0, testComp.numRemoveCalls)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -6,9 +6,17 @@ import com.github.quillraven.fleks.collection.compareEntity
 import com.github.quillraven.fleks.collection.compareEntityBy
 import kotlin.test.*
 
-private data class WorldTestComponent(var x: Float = 0f) : Component<WorldTestComponent>,
+private data class WorldTestComponent(
+    var x: Float = 0f,
+) : Component<WorldTestComponent>,
     Comparable<WorldTestComponent> {
     override fun type(): ComponentType<WorldTestComponent> = WorldTestComponent
+
+    var numAddCalls: Int = 0
+    var numRemoveCalls: Int = 0
+
+    override fun World.onAddComponent() { numAddCalls++ }
+    override fun World.onRemoveComponent() { numAddCalls-- }
 
     companion object : ComponentType<WorldTestComponent>()
 
@@ -50,9 +58,13 @@ private class WorldTestIteratingSystem(
     }
 }
 
-private class WorldTestInitSystem : IteratingSystem(family { all(WorldTestComponent) }) {
+private class WorldTestInitSystem(
+    onCreateComponent: (WorldTestComponent) -> Unit = {}
+) : IteratingSystem(family { all(WorldTestComponent) }) {
     init {
-        world.entity { it += WorldTestComponent() }
+        val comp = WorldTestComponent()
+        onCreateComponent(comp)
+        world.entity { it += comp }
     }
 
     override fun onTickEntity(entity: Entity) = Unit
@@ -435,37 +447,16 @@ internal class WorldTest {
     }
 
     @Test
-    fun createWorldWithComponentHooks() {
-        val w = configureWorld {
-            components {
-                onAdd(WorldTestComponent) { _, _ -> }
-                onRemove(WorldTestComponent) { _, _ -> }
-            }
-        }
-
-        val holder = w.componentService.holder(WorldTestComponent)
-        assertNotNull(holder.addHook)
-        assertNotNull(holder.removeHook)
-    }
-
-    @Test
     fun notifyComponentHooksDuringSystemCreation() {
-        var numAddCalls = 0
-        var numRemoveCalls = 0
-
+        var component: WorldTestComponent? = null
         configureWorld {
-            components {
-                onAdd(WorldTestComponent) { _, _ -> ++numAddCalls }
-                onRemove(WorldTestComponent) { _, _ -> ++numRemoveCalls }
-            }
-
             systems {
-                add(WorldTestInitSystem())
+                add(WorldTestInitSystem { component = it })
             }
         }
 
-        assertEquals(1, numAddCalls)
-        assertEquals(0, numRemoveCalls)
+        assertEquals(1, component?.numAddCalls)
+        assertEquals(0, component?.numRemoveCalls)
     }
 
     @Test
@@ -665,25 +656,20 @@ internal class WorldTest {
 
     @Test
     fun testLoadSnapshotWithThreeEntities() {
-        var numAddCalls = 0
-        var numRemoveCalls = 0
         val w = configureWorld {
             injectables {
                 add("42")
-            }
-
-            components {
-                onAdd(WorldTestComponent) { _, _ -> ++numAddCalls }
-                onRemove(WorldTestComponent) { _, _ -> ++numRemoveCalls }
             }
 
             systems {
                 add(WorldTestIteratingSystem())
             }
         }
+        val comp1 = WorldTestComponent()
+        val comp2 = WorldTestComponent()
         val snapshot = mapOf(
-            Entity(3) to listOf(WorldTestComponent(), WorldTestComponent2()),
-            Entity(5) to listOf(WorldTestComponent()),
+            Entity(3) to listOf(comp1, WorldTestComponent2()),
+            Entity(5) to listOf(comp2),
             Entity(7) to listOf()
         )
 
@@ -703,9 +689,12 @@ internal class WorldTest {
         }
         // 2 out of 3 loaded entities should be part of the IteratingSystem family
         assertEquals(2, w.system<WorldTestIteratingSystem>().numCallsEntity)
-        // 2 out of 3 loaded entities should notify the WorldTestComponentListener
-        assertEquals(2, numAddCalls)
-        assertEquals(0, numRemoveCalls)
+        // 2 out of 3 loaded entities have components with lifecycle methods
+        assertEquals(1, comp1.numAddCalls)
+        assertEquals(0, comp1.numRemoveCalls)
+        assertEquals(1, comp2.numAddCalls)
+        assertEquals(0, comp2.numRemoveCalls)
+
         assertEquals(3, actual.size)
     }
 


### PR DESCRIPTION
This PR adds component lifecycle methods `onAddComponent()` and `onRemoveComponent`, which replaces the component hooks. As such, this PR also removes component hooks.

Discussion of this change can be found in issue #103.

The TL;DR of #103 is that lifecycle methods have are just a better developer experience over component hooks, with next to no performance hit.

Tests and code documentation have also been updated.

The removal of component hooks has resulted in _slightly_ uglier tests, and I've pointed these out.