### PR TITLE
Added entities to the arguments for lifecycle methods

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -51,12 +51,12 @@ interface Component<T> {
     /**
      * Lifecycle method that gets called whenever a [component][Component] gets set for an [entity][Entity].
      */
-    fun World.onAddComponent() = Unit
+    fun World.onAddComponent(entity: Entity) = Unit
 
     /**
      * Lifecycle method that gets called whenever a [component][Component] gets removed from an [entity][Entity].
      */
-    fun World.onRemoveComponent() = Unit
+    fun World.onRemoveComponent(entity: Entity) = Unit
 }
 
 /**
@@ -99,14 +99,14 @@ class ComponentsHolder<T : Component<*>>(
             // method to correctly return false
             components[entity.id] = null
             existingCmp.run {
-                world.onRemoveComponent()
+                world.onRemoveComponent(entity)
             }
         }
 
         // set component and call lifecycle method
         components[entity.id] = component
         component.run {
-            world.onAddComponent()
+            world.onAddComponent(entity)
         }
     }
 
@@ -124,7 +124,7 @@ class ComponentsHolder<T : Component<*>>(
         // assign null before running the lifecycle method in order for 'contains' calls to correctly return false
         components[entity.id] = null
         existingCmp?.run {
-            world.onRemoveComponent()
+            world.onRemoveComponent(entity)
         }
     }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -28,12 +28,12 @@ internal class ComponentTest {
     ) : Component<ComponentTestWithLifecycleComponent> {
         override fun type() = ComponentTestWithLifecycleComponent
 
-        override fun World.onAddComponent() {
+        override fun World.onAddComponent(entity: Entity) {
             assertEquals(expectedWorld, this)
             numAddCalls++
         }
 
-        override fun World.onRemoveComponent() {
+        override fun World.onRemoveComponent(entity: Entity) {
             assertEquals(expectedWorld, this)
             numRemoveCalls++
         }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -23,6 +23,7 @@ internal class ComponentTest {
 
     private data class ComponentTestWithLifecycleComponent(
         val expectedWorld: World,
+        val expectedEntity: Entity,
         var numAddCalls: Int = 0,
         var numRemoveCalls: Int = 0
     ) : Component<ComponentTestWithLifecycleComponent> {
@@ -30,11 +31,13 @@ internal class ComponentTest {
 
         override fun World.onAddComponent(entity: Entity) {
             assertEquals(expectedWorld, this)
+            assertEquals(expectedEntity, entity)
             numAddCalls++
         }
 
         override fun World.onRemoveComponent(entity: Entity) {
             assertEquals(expectedWorld, this)
+            assertEquals(expectedEntity, entity)
             numRemoveCalls++
         }
 
@@ -149,7 +152,7 @@ internal class ComponentTest {
     @Test
     fun addAndRemoveComponentWithLifecycleMethod() {
         val expectedEntity = Entity(1)
-        val expectedComp = ComponentTestWithLifecycleComponent(testWorld)
+        val expectedComp = ComponentTestWithLifecycleComponent(testWorld, expectedEntity)
 
         val testHolderForLifecycleComponent = testService.holder(ComponentTestWithLifecycleComponent)
 
@@ -166,8 +169,8 @@ internal class ComponentTest {
     @Test
     fun addAndReplaceComponentWithLifecycleMethod() {
         val expectedEntity = Entity(1)
-        val expectedComp1 = ComponentTestWithLifecycleComponent(testWorld)
-        val expectedComp2 = ComponentTestWithLifecycleComponent(testWorld)
+        val expectedComp1 = ComponentTestWithLifecycleComponent(testWorld, expectedEntity)
+        val expectedComp2 = ComponentTestWithLifecycleComponent(testWorld, expectedEntity)
 
         val testHolderForLifecycleComponent = testService.holder(ComponentTestWithLifecycleComponent)
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
@@ -31,12 +31,12 @@ private data class Collider(
 
     var colliderId: String? = null
 
-    override fun World.onAddComponent() {
+    override fun World.onAddComponent(entity: Entity) {
         val provider = inject<ColliderService>()
         colliderId = provider.getId()
     }
 
-    override fun World.onRemoveComponent() {
+    override fun World.onRemoveComponent(entity: Entity) {
         colliderId = null
     }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -15,8 +15,8 @@ private data class WorldTestComponent(
     var numAddCalls: Int = 0
     var numRemoveCalls: Int = 0
 
-    override fun World.onAddComponent() { numAddCalls++ }
-    override fun World.onRemoveComponent() { numAddCalls-- }
+    override fun World.onAddComponent(entity: Entity) { numAddCalls++ }
+    override fun World.onRemoveComponent(entity: Entity) { numAddCalls-- }
 
     companion object : ComponentType<WorldTestComponent>()
 


### PR DESCRIPTION
I was updating the Fleks Wiki to remove component hooks in place of the new lifecycle methods, when I realised the example in the Wiki was no longer possible 🗿.

```kotlin
val onAdd: ComponentHook<Box2dComponent> = { entity, b2dCmp ->
    b2dCmp.body = inject<PhysicWorld>().createBody( /* body creation code omitted */)
    b2dCmp.body.userData = entity // No longer possible, no entity reference from the component!
}
```

So instead we should pass the respective entity as a parameter to the component lifecycle methods.

```kotlin
override fun World.onAddComponent(entity: Entity) {
    body = inject<PhysicWorld>().createBody( /* body creation code omitted */)
    body.userData = entity // 🎉
}
```
