### PR TITLE
Version 2.4

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 # Fleks
 
-[![LTS](https://img.shields.io/badge/LTS-2.3-orange.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/2.3/jar)
+[![LTS](https://img.shields.io/badge/LTS-2.4-orange.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/2.4/jar)
 [![Snapshot](https://img.shields.io/badge/Snapshot-2.4--SNAPSHOT-orange.svg)](https://s01.oss.sonatype.org/#nexus-search;gav~io.github.quillraven.fleks~~2.4-SNAPSHOT~~)
 
 [![Build Master](https://img.shields.io/github/actions/workflow/status/quillraven/fleks/build.yml?branch=master)](https://github.com/Quillraven/fleks/actions)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -71,26 +71,26 @@ To use Fleks add it as a dependency to your project:
 <dependency>
   <groupId>io.github.quillraven.fleks</groupId>
   <artifactId>Fleks-jvm</artifactId>
-  <version>2.3</version>
+  <version>2.4</version>
 </dependency>
 ```
 
 #### Gradle (Groovy)
 
 ```kotlin
-implementation 'io.github.quillraven.fleks:Fleks:2.3'
+implementation 'io.github.quillraven.fleks:Fleks:2.4'
 ```
 
 #### Gradle (Kotlin)
 
 ```kotlin
-implementation("io.github.quillraven.fleks:Fleks:2.3")
+implementation("io.github.quillraven.fleks:Fleks:2.4")
 ```
 
 #### KorGE
 
 ```kotlin
-dependencyMulti("io.github.quillraven.fleks:Fleks:2.3", registerPlugin = false)
+dependencyMulti("io.github.quillraven.fleks:Fleks:2.4", registerPlugin = false)
 ```
 
 If you want to use the Snapshot version then you need to add the snapshot repository as well:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.github.quillraven.fleks"
-version = "2.4-SNAPSHOT"
+version = "2.4"
 
 kotlin {
     jvm {

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -51,12 +51,12 @@ interface Component<T> {
     /**
      * Lifecycle method that gets called whenever a [component][Component] gets set for an [entity][Entity].
      */
-    fun World.onAddComponent(entity: Entity) = Unit
+    fun World.onAdd(entity: Entity) = Unit
 
     /**
      * Lifecycle method that gets called whenever a [component][Component] gets removed from an [entity][Entity].
      */
-    fun World.onRemoveComponent(entity: Entity) = Unit
+    fun World.onRemove(entity: Entity) = Unit
 }
 
 /**
@@ -82,9 +82,9 @@ class ComponentsHolder<T : Component<*>>(
 
     /**
      * Sets the [component] for the given [entity].
-     * If the [entity] already had a component, the [onRemoveComponent][Component.onRemoveComponent] lifecycle method
+     * If the [entity] already had a component, the [onRemove][Component.onRemove] lifecycle method
      * will be called.
-     * After the [component] is assigned to the [entity], the [onAddComponent][Component.onAddComponent] lifecycle method
+     * After the [component] is assigned to the [entity], the [onAdd][Component.onAdd] lifecycle method
      * will be called.
      */
     operator fun set(entity: Entity, component: T) {
@@ -94,25 +94,21 @@ class ComponentsHolder<T : Component<*>>(
         }
 
         // check if the remove lifecycle method of the previous component needs to be called
-        components[entity.id]?.let { existingCmp ->
+        components[entity.id]?.run {
             // assign current component to null in order for 'contains' calls inside the lifecycle
             // method to correctly return false
             components[entity.id] = null
-            existingCmp.run {
-                world.onRemoveComponent(entity)
-            }
+            world.onRemove(entity)
         }
 
         // set component and call lifecycle method
         components[entity.id] = component
-        component.run {
-            world.onAddComponent(entity)
-        }
+        component.run { world.onAdd(entity) }
     }
 
     /**
      * Removes a component of the specific type from the given [entity].
-     * If the entity has such a component, its [onRemoveComponent][Component.onRemoveComponent] lifecycle method will
+     * If the entity has such a component, its [onRemove][Component.onRemove] lifecycle method will
      * be called.
      *
      * @throws [IndexOutOfBoundsException] if the id of the [entity] exceeds the components' capacity.
@@ -123,9 +119,7 @@ class ComponentsHolder<T : Component<*>>(
         val existingCmp = components[entity.id]
         // assign null before running the lifecycle method in order for 'contains' calls to correctly return false
         components[entity.id] = null
-        existingCmp?.run {
-            world.onRemoveComponent(entity)
-        }
+        existingCmp?.run { world.onRemove(entity) }
     }
 
     /**

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -92,11 +92,11 @@ open class EntityCreateContext(
     /**
      * Adds the [component] to the [entity][Entity].
      *
-     * The [onAddComponent][Component.onAddComponent] lifecycle method
+     * The [onAdd][Component.onAdd] lifecycle method
      * gets called after the [component] is assigned to the [entity][Entity].
      *
-     * If the [entity][Entity] already had such a [component] then the [onRemoveComponent][Component.onRemoveComponent]
-     * lifecycle method gets called on the previously assigned component before the [onAddComponent][Component.onAddComponent]
+     * If the [entity][Entity] already had such a [component] then the [onRemove][Component.onRemove]
+     * lifecycle method gets called on the previously assigned component before the [onAdd][Component.onAdd]
      * lifecycle method is called on the new component.
      */
     inline operator fun <reified T : Component<T>> Entity.plusAssign(component: T) {
@@ -111,11 +111,11 @@ open class EntityCreateContext(
      * in exceptional cases.
      * It is preferred to use the [plusAssign] function whenever possible to have type-safety.
      *
-     * The [onAddComponent][Component.onAddComponent] lifecycle method
+     * The [onAdd][Component.onAdd] lifecycle method
      * gets called after each component is assigned to the [entity][Entity].
      *
-     * If the [entity][Entity] already has such a component then the [onRemoveComponent][Component.onRemoveComponent]
-     * lifecycle method gets called on the previously assigned component before the [onAddComponent][Component.onAddComponent]
+     * If the [entity][Entity] already has such a component then the [onRemove][Component.onRemove]
+     * lifecycle method gets called on the previously assigned component before the [onAdd][Component.onAdd]
      * lifecycle method is called on the new component.
      */
     operator fun Entity.plusAssign(components: List<Component<*>>) {
@@ -139,7 +139,7 @@ class EntityUpdateContext(
     /**
      * Removes a [component][Component] of the given [type] from the [entity][Entity].
      *
-     * Calls the [onRemoveComponent][Component.onRemoveComponent] lifecycle method on the component being removed.
+     * Calls the [onRemove][Component.onRemove] lifecycle method on the component being removed.
      *
      * @throws [IndexOutOfBoundsException] if the id of the [entity][Entity] exceeds the internal components' capacity.
      * This can only happen when the [entity][Entity] never had such a component.

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -29,13 +29,13 @@ internal class ComponentTest {
     ) : Component<ComponentTestWithLifecycleComponent> {
         override fun type() = ComponentTestWithLifecycleComponent
 
-        override fun World.onAddComponent(entity: Entity) {
+        override fun World.onAdd(entity: Entity) {
             assertEquals(expectedWorld, this)
             assertEquals(expectedEntity, entity)
             numAddCalls++
         }
 
-        override fun World.onRemoveComponent(entity: Entity) {
+        override fun World.onRemove(entity: Entity) {
             assertEquals(expectedWorld, this)
             assertEquals(expectedEntity, entity)
             numRemoveCalls++
@@ -178,7 +178,7 @@ internal class ComponentTest {
         assertEquals(1, expectedComp1.numAddCalls)
         assertEquals(0, expectedComp1.numRemoveCalls)
 
-        // Should trigger onRemoveComponent on expectedComp1
+        // Should trigger onRemove on expectedComp1
         testHolderForLifecycleComponent[expectedEntity] = expectedComp2
         assertEquals(1, expectedComp1.numAddCalls)
         assertEquals(1, expectedComp1.numRemoveCalls)

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
@@ -31,12 +31,12 @@ private data class Collider(
 
     var colliderId: String? = null
 
-    override fun World.onAddComponent(entity: Entity) {
+    override fun World.onAdd(entity: Entity) {
         val provider = inject<ColliderService>()
         colliderId = provider.getId()
     }
 
-    override fun World.onRemoveComponent(entity: Entity) {
+    override fun World.onRemove(entity: Entity) {
         colliderId = null
     }
 
@@ -177,12 +177,12 @@ class Fleks2TDD {
             }
         }
 
-        // entity that triggers onAddComponent lifecycle method
+        // entity that triggers onAdd lifecycle method
         assertEquals(null, addComponent.colliderId)
         testWorld.entity { it += addComponent }
         assertEquals("0", addComponent.colliderId)
 
-        // entity that triggers onRemoveComponent lifecycle method
+        // entity that triggers onRemove lifecycle method
         val removeEntity = testWorld.entity { it += removeComponent }
         assertEquals("1", removeComponent.colliderId)
         with(testWorld) { removeEntity.configure { it -= Collider } }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -15,8 +15,15 @@ private data class WorldTestComponent(
     var numAddCalls: Int = 0
     var numRemoveCalls: Int = 0
 
-    override fun World.onAddComponent(entity: Entity) { numAddCalls++ }
-    override fun World.onRemoveComponent(entity: Entity) { numAddCalls-- }
+    override fun World.onAdd(entity: Entity) {
+        assertTrue(entity has WorldTestComponent)
+        numAddCalls++
+    }
+
+    override fun World.onRemove(entity: Entity) {
+        assertFalse(entity has WorldTestComponent)
+        numAddCalls--
+    }
 
     companion object : ComponentType<WorldTestComponent>()
 
@@ -58,7 +65,7 @@ private class WorldTestIteratingSystem(
     }
 }
 
-private class WorldTestInitSystem: IteratingSystem(family { all(WorldTestComponent) }) {
+private class WorldTestInitSystem : IteratingSystem(family { all(WorldTestComponent) }) {
     init {
         world.entity { it += WorldTestComponent() }
     }


### PR DESCRIPTION
This version contains some breaking changes which add some more flexibility to Fleks and also keep it up-to-date with other technologies. The most important change is the requirement of Java 11 instead of 8. This seems to be safe nowadays, even for Android. For LibGDX users, please use Gdx-Liftoff as your setup tool which already creates proper Java11 projects.

Changelog:
- Several version updates:
  - Kotlin 1.7.21 -> 1.9.0
  - Dokka 1.7.20 -> 1.8.20
  - Kotlinx-benchmark 0.4.5 -> 0.4.8
  - Gradle 7.6 -> 8.2.1
- `world` function got renamed to `configureWorld`. I got several comments on my YT videos that people got confused between `world` and `World` (constructor vs DSL function). To make it clear, it got now renamed to `configureWorld`
- Also, the order of `configureWorld` functions no longer matters. Before, it was mandatory to call `systems` last. Now you are free to call `injectables`, `systems`, `family` in any order.
- Kotlinx-serialization got added to Fleks. The `@Serializable` annotation is now part of the entity and makes it easier for certain serialization topics. This was suggested by the KorGE community.
- A new `EntityProvider` interface got added which allows to provide your own entity ID logic. Per default it will still use the Fleks built-in recycle ID logic. However, you can now define an `EntityProvider` inside the `configureWorld` function to use your own implementation. This should improve the usability for network gaming.
- We now have a new built setup with Gradle 8.x, thanks to @aSemy. The entire gradle setup is now more modern and easier to maintain. Also, Snapshot and LTS releases are now automatically published when the build is successful.
- In addition to the gradle setup changes, Fleks now supports more native targets:
  - linuxarm64
  - macosarm64
  - linuxx64
  - macosx64
  - mingwx64
- `ComponentHook`s got replaced by normal component functions. The `Component` interface now has an `onAddComponent` and `onRemoveComponent` function which can be overridden to add custom functionality. Both functions run in the context of a `World`. This makes it easier to write such logic because you no longer need to add the `ComponentHook` to your world configuration. Thanks to @geist-2501 for the contribution!
- documentation fixes for `Entity.configure` function (@aSemy)

For more information about the new functionality, please check out the updated [wiki](https://github.com/Quillraven/Fleks/wiki).

----

@jobe-m: as always, please let me know if everything is working in your KorGE example :)

@geist-2501: Shall we rename `onAddComponent` and `onRemoveComponent` to `onAdd` and `onRemove`? Since they are functions of a component, I think the `Component` part of the name is redundant. What do you think? I can add the change to this PR.

And btw, wiki is not yet updated ;) Will do that, when the version goes live.