### PR TITLE
tweak entity modification KDocs

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -64,10 +64,14 @@ abstract class EntityComponentContext(
      * **Attention** Make sure that you only modify the entity of the current scope.
      * Otherwise, you will get wrong behavior for families. E.g. don't do this:
      *
-     *     entity.configure {
-     *         // don't do this
-     *         somOtherEntity += Position()
-     *     }
+     * ```
+     * entity.configure {
+     *     // modifying the current entity is allowed ✅
+     *     it += Position()
+     *     // don't modify other entities ❌
+     *     someOtherEntity += Position()
+     * }
+     * ```
      */
     inline fun Entity.configure(configuration: EntityUpdateContext.(Entity) -> Unit) =
         componentService.world.entityService.configure(this, configuration)

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -329,10 +329,14 @@ class World internal constructor(
      * **Attention** Make sure that you only modify the entity of the current scope.
      * Otherwise, you will get wrong behavior for families. E.g. don't do this:
      *
-     *     entity {
-     *         // don't do this
-     *         somOtherEntity += Position()
-     *     }
+     * ```
+     * entity {
+     *     // modifying the current entity is allowed ✅
+     *     it += Position()
+     *     // don't modify other entities ❌
+     *     someOtherEntity += Position()
+     * }
+     * ```
      */
     inline fun entity(configuration: EntityCreateContext.(Entity) -> Unit = {}): Entity {
         return entityService.create(configuration)


### PR DESCRIPTION
Hi 👋, just a small suggestion for docs about the entity modification restriction, to make them more clear. This is my subjective suggestion, so feedback would be very welcome!

I thought I'd make a PR directly so it's easier to view my suggested changes, I hope that's okay!

### Summary

- fix typo, `somOtherEntity` -> `someOtherEntity`
- add correct example to contrast with incorrect usage
- use emoji to highlight correct/incorrect approaches