### PR TITLE
Adjust auto-publishing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
 on:
+  release:
+    types: [ created ]
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
           arguments: build --stacktrace
+
+  publish:
+    # only publish after 'build' was successful, and this workflow is running on master branch
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/publish.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: Build
 on:
-  release:
-    types: [ created ]
   push:
     branches:
       - master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,7 @@
 name: Publish
 on:
-  workflow_run:
-    workflows: [ "Build" ]
-    types:
-      - completed
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: "${{ github.workflow }}"
@@ -12,7 +9,7 @@ concurrency:
 
 jobs:
   maven-publish:
-    if: ${{ (github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: macos-latest # macOS supports building all Kotlin targets
 
     permissions:


### PR DESCRIPTION
Adjust the 'publish' workflow so that it's called by the 'build' workflow as a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows)

This hopefully fixes the issue described in #106 

> @aSemy : any idea why "Publish" workflow gets triggered for PRs? I thought the if condition in the job should prevent that? Obviously, I am wrong :D
> 
> _Originally posted by @Quillraven in https://github.com/Quillraven/Fleks/issues/106#issuecomment-1637548926_


I'm not 100% certain that this will solve the issue, so please double check it!