### PR TITLE
Optimization and cleanup for bit arrays.

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
@@ -43,7 +43,12 @@ class BitArray(
     fun set(idx: Int) {
         val word = idx ushr 6
         if (word >= bits.size) {
-            bits = bits.copyOf(max(word + word, 1))
+            // magic.
+            // ((word or -word) shr 63) is an idiom that returns 0 if word is 0, or -1 otherwise.
+            // Calling inv() on that makes it -1 if word is 0, or 0 otherwise.
+            // With the rest, this makes the copy use twice as many Long items as before, or use
+            // one Long item if word is 0 (and bits.size is currently 0, a precondition).
+            bits = bits.copyOf(word + word - ((word or -word) shr 63).inv())
         }
         bits[word] = bits[word] or (1L shl idx)
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
@@ -102,12 +102,7 @@ class BitArray(
             val bitsAtWord = bits[word]
             if (bitsAtWord != 0L) {
                 val w = word shl 6
-
-                for (bit in 63 downTo 0) {
-                    if ((bitsAtWord and (1L shl bit)) != 0L) {
-                        return w + bit + 1
-                    }
-                }
+                return w + (64 - bitsAtWord.countLeadingZeroBits())
             }
         }
         return 0
@@ -119,14 +114,7 @@ class BitArray(
     fun numBits(): Int {
         var sum = 0
         for (word in bits.size - 1 downTo 0) {
-            val bitsAtWord = bits[word]
-            if (bitsAtWord != 0L) {
-                for (bit in 63 downTo 0) {
-                    if ((bitsAtWord and (1L shl bit)) != 0L) {
-                        sum++
-                    }
-                }
-            }
+            sum += bits[word].countOneBits()
         }
         return sum
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
@@ -419,6 +419,19 @@ class MutableEntityBag(
     }
 
     /**
+     * Resets [size] to zero, clears any [entity][Entity] of the bag, and if necessary,
+     * resizes the bag to be able to fit the given [capacity] of [entities][Entity].
+     */
+    fun clearEnsuringCapacity(capacity: Int) {
+        if (capacity > values.size) {
+            values = Array(capacity + 1) { Entity(-1) }
+        } else {
+            values.fill(Entity(-1))
+        }
+        size = 0
+    }
+
+    /**
      * Sorts the bag according to the given [comparator].
      */
     fun sort(comparator: EntityComparator) {

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
@@ -7,7 +7,7 @@ import kotlin.random.Random
 
 interface EntityBag {
     /**
-     * Returns the size of the [MutableEntityBag].
+     * Returns the size of the [EntityBag].
      */
     val size: Int
 
@@ -413,7 +413,7 @@ class MutableEntityBag(
      * Resizes the bag to fit in the given [capacity] of [entities][Entity] if necessary.
      */
     fun ensureCapacity(capacity: Int) {
-        if (capacity >= values.size) {
+        if (capacity > values.size) {
             values = values.copyInto(Array(capacity + 1) { Entity(-1) })
         }
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityBagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityBagTest.kt
@@ -88,6 +88,10 @@ class EntityBagTest {
         bag.ensureCapacity(7)
 
         assertEquals(8, bag.capacity)
+
+        bag.ensureCapacity(8)
+
+        assertEquals(8, bag.capacity)
     }
 
     @Test


### PR DESCRIPTION
This is organized logically by commit, and each commit has a (sometimes long-winded) comment. Long story short, addRemove() in the benchmarks goes from 1327 ops/second to 2161 ops/second. The number seems large because I tested with 1000 entities (instead of 10,000) and 5 world updates (instead of 1000) so that I could get meaningful results with short-ish iteration times. That mattered because the benchmark seems to have problems running out of heap if it spends too long on one iteration, though I don't think I encountered this with Fleks -- it was an issue with the Artemis benchmark.

There's lots of bitwise magic here. I'm more than happy to explain any part that doesn't make sense. Bitwise operations are usually quite fast compared to anything that deals with objects, so I'm always happy to see them being put to productive use. The main thing I tried to do was to strip down any of the places where indices 0-63 were looped over in each Long, since that takes more time than necessary in a sparse Long (one with few bits set). There's a new clearEnsuringCapacity() method in MutableEntityBag; it is functionally just like:

```kt
clear()
ensureCapacity(capacity)
```

But avoids copying the empty array without the need to. This is something that some of libGDX's collections also have.

Let me know what I can do to help!