### PR TITLE
#113 entity version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,11 @@ kotlin {
 
 benchmark {
     configurations {
+        create("FleksOnly") {
+            include("Fleks")
+            exclude("Artemis|Ashley")
+        }
+
         create("FleksAddRemoveOnly") {
             include("addRemove")
             exclude("Artemis|Ashley")

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -42,6 +42,10 @@ class Bag<T>(
         return values[index] ?: throw NoSuchElementException("Bag has no value at index $index")
     }
 
+    inline fun getOrNull(index: Int): T? {
+        return values[index]
+    }
+
     fun hasNoValueAtIndex(index: Int): Boolean {
         return index >= size || values[index] == null
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -61,6 +61,15 @@ class Bag<T>(
         return false
     }
 
+    fun removeIndex(index: Int): Boolean {
+        if (values[index] != null) {
+            values[index] = values[--size]
+            values[size] = null
+            return true
+        }
+        return false
+    }
+
     fun clear() {
         values.fill(null)
         size = 0

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -7,9 +7,8 @@ import kotlin.jvm.JvmInline
 /**
  * An entity of a [world][World]. It represents a unique id.
  */
-@JvmInline
 @Serializable
-value class Entity(val id: Int)
+data class Entity(val id: Int, val version: Int = 0)
 
 /**
  * Type alias for an optional hook function for an [EntityService].

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -7,8 +7,9 @@ import kotlin.jvm.JvmInline
 /**
  * An entity of a [world][World]. It represents a unique id.
  */
+@JvmInline
 @Serializable
-data class Entity(val id: Int, val version: Int = 0)
+value class Entity(val id: Int)
 
 /**
  * Type alias for an optional hook function for an [EntityService].

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -531,6 +531,7 @@ class EntityService(
 
             // invalidate EntityRef
             entityRefs.getOrNull(entity.id)?.valid = false
+            entityRefs.removeIndex(entity.id)
 
             // update families
             world.allFamilies.forEach { it.onEntityRemoved(entity) }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityRefTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityRefTest.kt
@@ -1,0 +1,42 @@
+package com.github.quillraven.fleks
+
+import kotlin.test.*
+
+data class EntityRefComponent(val ref: EntityRef) : Component<EntityRefComponent> {
+    override fun type() = EntityRefComponent
+
+    companion object : ComponentType<EntityRefComponent>()
+}
+
+class EntityRefTest {
+
+    @Test
+    fun testEntityRefValid() {
+        lateinit var entityRefCmp: EntityRefComponent
+        val world = configureWorld { }
+        val entity1 = world.entity()
+        world.entity { e ->
+            e += EntityRefComponent(entity1.ref()).also { entityRefCmp = it }
+        }
+
+        assertTrue(entityRefCmp.ref.valid)
+        assertEquals(entity1, entityRefCmp.ref.entity)
+
+        world -= entity1
+        assertFalse(entityRefCmp.ref.valid)
+        assertEquals(entity1, entityRefCmp.ref.entity)
+    }
+
+    @Test
+    fun testEntityRefInstance() {
+        val world = configureWorld { }
+        val entity1 = world.entity()
+
+        with(world) {
+            val ref1 = entity1.ref()
+            val ref2 = entity1.ref()
+            assertSame(ref1, ref2)
+        }
+    }
+
+}


### PR DESCRIPTION
PR for #113 (WIP).

@dragbone: I quickly run the benchmarks when changing `Entity` from a value class to a data class.

```kotlin
// from this
@JvmInline
@Serializable
value class Entity(val id: Int)


// to this
@Serializable
data class Entity(val id: Int, val version: Int = 0)
```

To my surprise, this does not seem to have any impact on the performance. Maybe because everything internally still works with the id (=int) and somehow that already gets optimized to perfection by the compiler/JVM? Don't know about the otheer platforms.

Here is the result:
```
# value class
jvmBenchmarks summary:
Benchmark                  Mode  Cnt     Score     Error  Units
FleksBenchmark.addRemove  thrpt    5  3005,834 ± 104,474  ops/s
FleksBenchmark.complex    thrpt    5     1,515 ±   0,308  ops/s
FleksBenchmark.simple     thrpt    5    91,181 ±   5,372  ops/s

# data class
jvmBenchmarks summary:
Benchmark                  Mode  Cnt     Score     Error  Units
FleksBenchmark.addRemove  thrpt    5  3011,912 ± 216,568  ops/s
FleksBenchmark.complex    thrpt    5     1,788 ±   0,094  ops/s
FleksBenchmark.simple     thrpt    5    87,405 ±  32,696  ops/s
```

Imo we can go ahead with this change as it is a nice feature when it comes to safe referencing entities in components and it seems to have no negative effect from what I can tell.

----

One thing that comes to my mind is serialization. Before it was just the id of the entity but now you get an id + version. The version is imo irrelevant for seralization because when you load a save state you most likely start again with version 0 for all entities?

@jobe-m: do you have any concerns about changing `Entity` from a value class to a data class?

@dragbone: If you like, you can start from this branch and add the logic to increase the version when an entity gets reused and add the tests for it.
The correct place should be the `create` method of the `DefaultEntityProvider`. And also the `contains` method of the `DefaultEntityProvider` to check for the correct version.

If you don't have time then I will try to finalize it in October.