### PR TITLE
add entity tag support

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bag.kt
@@ -45,7 +45,7 @@ class Bag<T>(
     /**
      * Returns the element at position [index] or null if there is no element or if [index] is out of bounds
      */
-    inline fun getOrNull(index: Int): T? = values.getOrNull(index)
+    fun getOrNull(index: Int): T? = values.getOrNull(index)
 
     fun hasNoValueAtIndex(index: Int): Boolean {
         return index >= size || index < 0 || values[index] == null

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/bitArray.kt
@@ -137,6 +137,22 @@ class BitArray(
         }
     }
 
+    inline fun clearAndForEachSetBit(action: (Int) -> Unit) {
+        for (word in bits.size - 1 downTo 0) {
+            var bitsAtWord = bits[word]
+            if (bitsAtWord != 0L) {
+                val w = word shl 6
+                while (bitsAtWord != 0L) {
+                    bits[word] = 0L // clear
+                    // gets the distance from the start of the word to the highest (leftmost) bit
+                    val bit = 63 - bitsAtWord.countLeadingZeroBits()
+                    action(w + bit)
+                    bitsAtWord = (bitsAtWord xor (1L shl bit)) // removes highest bit
+                }
+            }
+        }
+    }
+
     override fun hashCode(): Int {
         if (bits.isEmpty()) {
             return 0

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -5,21 +5,30 @@ import com.github.quillraven.fleks.collection.bag
 import kotlin.math.max
 import kotlin.native.concurrent.ThreadLocal
 
+interface UniqueId<T> {
+    val id: Int
+
+    @ThreadLocal
+    companion object {
+        internal var nextId = 0
+    }
+}
+
 /**
  * A class that assigns a unique [id] per type of [Component] starting from 0.
  * This [id] is used internally by Fleks as an index for some arrays.
  * Every [Component] class must have at least one [ComponentType].
  */
-abstract class ComponentType<T> {
-    val id: Int = nextId++
-
-    @ThreadLocal
-    companion object {
-        private var nextId = 0
-    }
+abstract class ComponentType<T> : UniqueId<T> {
+    override val id: Int = UniqueId.nextId++
 }
 
 typealias EntityTag = ComponentType<Any>
+
+typealias EntityTags = UniqueId<Any>
+
+inline fun entityTagsOf(): EntityTag = object : EntityTag() {}
+
 
 /**
  * Function to create an object for a [ComponentType] of type T.

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -9,6 +9,8 @@ import kotlin.native.concurrent.ThreadLocal
  * An interface that specifies a unique [id].
  * This [id] is used internally by Fleks as an index for some arrays.
  */
+// interface was necessary for (#118) to support enum classes as entity tags
+// because enum classes can only inherit from an interface and not from an abstract class.
 interface UniqueId<T> {
     val id: Int
 
@@ -228,14 +230,12 @@ class ComponentService {
     }
 
     /**
-     * Returns the [ComponentsHolder] of the given [index] inside the [holdersBag]. The index
-     * is linked to the id of a [ComponentType].
+     * Returns the [ComponentsHolder] of the given [index] inside the [holdersBag] or null.
+     * The index is linked to the id of a [ComponentType].
      * This function is only used internally at safe areas to speed up certain processes like
      * removing an [entity][Entity] or creating a snapshot via [World.snapshot].
-     *
-     * @throws [IndexOutOfBoundsException] if the [index] exceeds the bag's capacity.
      */
-    internal fun holderByIndex(index: Int): ComponentsHolder<*> {
-        return holdersBag[index]
+    internal fun holderByIndexOrNull(index: Int): ComponentsHolder<*>? {
+        return holdersBag.getOrNull(index)
     }
 }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -27,7 +27,7 @@ typealias EntityTag = ComponentType<Any>
 
 typealias EntityTags = UniqueId<Any>
 
-inline fun entityTagOf(): EntityTag = object : EntityTag() {}
+fun entityTagOf(): EntityTag = object : EntityTag() {}
 
 
 /**

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -5,6 +5,10 @@ import com.github.quillraven.fleks.collection.bag
 import kotlin.math.max
 import kotlin.native.concurrent.ThreadLocal
 
+/**
+ * An interface that specifies a unique [id].
+ * This [id] is used internally by Fleks as an index for some arrays.
+ */
 interface UniqueId<T> {
     val id: Int
 
@@ -15,26 +19,45 @@ interface UniqueId<T> {
 }
 
 /**
- * A class that assigns a unique [id] per type of [Component] starting from 0.
- * This [id] is used internally by Fleks as an index for some arrays.
- * Every [Component] class must have at least one [ComponentType].
+ * An abstract class that assigns a unique [id] per type of [Component] starting from 0.
+ * Every [Component] class must have at least one [ComponentType] which serves
+ * as a [UniqueId].
  */
 abstract class ComponentType<T> : UniqueId<T> {
     override val id: Int = UniqueId.nextId++
 }
-
-typealias EntityTag = ComponentType<Any>
-
-typealias EntityTags = UniqueId<Any>
-
-fun entityTagOf(): EntityTag = object : EntityTag() {}
-
 
 /**
  * Function to create an object for a [ComponentType] of type T.
  * This is a convenience function for [components][Component] that have more than one [ComponentType].
  */
 inline fun <reified T> componentTypeOf(): ComponentType<T> = object : ComponentType<T>() {}
+
+/**
+ * Type alias for a special type of [ComponentType] that is used to tag [entities][Entity].
+ * A tag is a special form of a [Component] that does not have any data. It is stored
+ * more efficiently when compared to an empty [Component] and should therefore be preferred
+ * in those cases.
+ */
+typealias EntityTag = ComponentType<Any>
+
+/**
+ * Type alias for a special type of [UniqueId]. It can be used to make values of an enum
+ * class an [EntityTag].
+ *
+ * ```
+ * enum class MyTags : EntityTags by entityTagOf() {
+ *     TAG_A, TAG_B
+ * }
+ * ```
+ */
+typealias EntityTags = UniqueId<Any>
+
+/**
+ * Function to create an object for an [EntityTag].
+ * It can be used to make values of an enum class an [EntityTag]. Refer to [EntityTags].
+ */
+fun entityTagOf(): EntityTag = object : EntityTag() {}
 
 /**
  * An interface that must be implemented by any component that is used for Fleks.

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -19,6 +19,8 @@ abstract class ComponentType<T> {
     }
 }
 
+typealias EntityTag = ComponentType<Any>
+
 /**
  * Function to create an object for a [ComponentType] of type T.
  * This is a convenience function for [components][Component] that have more than one [ComponentType].

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/component.kt
@@ -27,7 +27,7 @@ typealias EntityTag = ComponentType<Any>
 
 typealias EntityTags = UniqueId<Any>
 
-inline fun entityTagsOf(): EntityTag = object : EntityTag() {}
+inline fun entityTagOf(): EntityTag = object : EntityTag() {}
 
 
 /**

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -2,6 +2,7 @@ package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.*
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmName
 
 /**
  * An entity of a [world][World]. It represents a unique identifier that is the combination
@@ -147,6 +148,14 @@ open class EntityCreateContext(
         // the entity's component mask just knows about the tag's id.
         // However, a snapshot should contain the real object instances related to an entity.
         componentService.world.tagCache[tag.id] = tag
+    }
+
+    /**
+     * Sets all [tags][EntityTag] on the given [entity][Entity].
+     */
+    @JvmName("plusAssignTags")
+    operator fun Entity.plusAssign(tags: List<UniqueId<*>>) {
+        tags.forEach { this += it }
     }
 
 }
@@ -500,7 +509,10 @@ class EntityService(
         }
 
         // set new tags
-        snapshot.tags.forEach { compMask.set(it.id) }
+        snapshot.tags.forEach {
+            compMask.set(it.id)
+            world.tagCache[it.id] = it
+        }
 
         // notify families
         world.allFamilies.forEach { it.onEntityCfgChanged(entity, compMask) }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -39,7 +39,7 @@ abstract class EntityComponentContext(
     inline operator fun <reified T : Component<*>> Entity.get(type: ComponentType<T>): T =
         componentService.holder(type)[this]
 
-    inline operator fun Entity.get(tag: ComponentType<*>): Boolean =
+    inline operator fun Entity.get(tag: UniqueId<*>): Boolean =
         componentService.world.entityService.compMasks[this.id][tag.id]
 
     /**
@@ -140,7 +140,7 @@ open class EntityCreateContext(
         }
     }
 
-    operator fun Entity.set(tag: ComponentType<*>, value: Boolean) {
+    operator fun Entity.set(tag: UniqueId<*>, value: Boolean) {
         if (value) {
             compMasks[this.id].set(tag.id)
         } else {

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -140,13 +140,8 @@ open class EntityCreateContext(
         }
     }
 
-    operator fun Entity.set(tag: UniqueId<*>, value: Boolean) {
-        if (value) {
-            compMasks[this.id].set(tag.id)
-        } else {
-            compMasks[this.id].clear(tag.id)
-        }
-    }
+    inline operator fun Entity.plusAssign(tag: UniqueId<*>) = compMasks[this.id].set(tag.id)
+
 }
 
 /**
@@ -191,6 +186,8 @@ class EntityUpdateContext(
         holder[this] = newCmp
         return newCmp
     }
+
+    inline operator fun Entity.minusAssign(tag: UniqueId<*>) = compMasks[this.id].clear(tag.id)
 }
 
 /**

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -39,6 +39,9 @@ abstract class EntityComponentContext(
     inline operator fun <reified T : Component<*>> Entity.get(type: ComponentType<T>): T =
         componentService.holder(type)[this]
 
+    inline operator fun Entity.get(tag: ComponentType<*>): Boolean =
+        componentService.world.entityService.compMasks[this.id][tag.id]
+
     /**
      * Returns a [component][Component] of the given [type] for the [entity][Entity]
      * or null if the [entity][Entity] does not have such a [component][Component].
@@ -134,6 +137,14 @@ open class EntityCreateContext(
             compMasks[this.id].set(compType.id)
             val holder = componentService.wildcardHolder(compType)
             holder.setWildcard(this, cmp)
+        }
+    }
+
+    operator fun Entity.set(tag: ComponentType<*>, value: Boolean) {
+        if (value) {
+            compMasks[this.id].set(tag.id)
+        } else {
+            compMasks[this.id].clear(tag.id)
         }
     }
 }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
@@ -26,7 +26,7 @@ data class FamilyDefinition(
     /**
      * Any [entity][Entity] must have all given [types] to be part of the [family][Family].
      */
-    fun all(vararg types: ComponentType<*>): FamilyDefinition {
+    fun all(vararg types: UniqueId<*>): FamilyDefinition {
         allOf = BitArray(types.size).also { bits ->
             types.forEach { bits.set(it.id) }
         }
@@ -36,7 +36,7 @@ data class FamilyDefinition(
     /**
      * Any [entity][Entity] must not have any of the given [types] to be part of the [family][Family].
      */
-    fun none(vararg types: ComponentType<*>): FamilyDefinition {
+    fun none(vararg types: UniqueId<*>): FamilyDefinition {
         noneOf = BitArray(types.size).also { bits ->
             types.forEach { bits.set(it.id) }
         }
@@ -46,7 +46,7 @@ data class FamilyDefinition(
     /**
      * Any [entity][Entity] must have at least one of the given [types] to be part of the [family][Family].
      */
-    fun any(vararg types: ComponentType<*>): FamilyDefinition {
+    fun any(vararg types: UniqueId<*>): FamilyDefinition {
         anyOf = BitArray(types.size).also { bits ->
             types.forEach { bits.set(it.id) }
         }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -251,7 +251,7 @@ class World internal constructor(
     init {
         /**
          * Maybe because of design flaws, the world reference of the ComponentService must be
-         * set in the world's constructor because the parent class (=BaseEntityExtensions) already
+         * set in the world's constructor because the parent class (=EntityComponentContext) already
          * requires a ComponentService, and it is not possible to pass "this" reference directly.
          *
          * That's why it is happening here to set it as soon as possible.

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -144,7 +144,7 @@ internal class ComponentTest {
 
     @Test
     fun getHolderByComponentId() {
-        val actual = testService.holderByIndex(0)
+        val actual = testService.holderByIndexOrNull(0)
 
         assertSame(testHolder, actual)
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -15,6 +15,12 @@ enum class TestTags : EntityTags by entityTagOf() {
     PLAYER, COLLISION
 }
 
+class TestTagComponent : Component<TestTagComponent> {
+    override fun type() = TestTagComponent
+
+    companion object : ComponentType<TestTagComponent>()
+}
+
 class EntityTagTest {
 
     @Test
@@ -65,6 +71,59 @@ class EntityTagTest {
             entity.configure { it -= TestTags.PLAYER }
 
             assertTrue(entity hasNo TestTags.PLAYER)
+        }
+    }
+
+    @Test
+    fun testRemoveEntityWithTag() {
+        val world = configureWorld {}
+        val entity = world.entity { it += TestTags.PLAYER }
+
+        with(world) {
+            entity.remove()
+
+            assertFalse(entity in world)
+        }
+    }
+
+    @Test
+    fun testSnapshotWithTag() {
+        val world = configureWorld {}
+        val entity = world.entity { it += TestTags.PLAYER }
+
+        val snapshot = world.snapshotOf(entity)
+        assertEquals(TestTags.PLAYER, snapshot.tags[0])
+
+        world.removeAll(true)
+        with(world) {
+            assertFalse(entity has TestTags.PLAYER)
+            world.loadSnapshot(mapOf(entity to snapshot))
+            assertTrue(entity has TestTags.PLAYER)
+        }
+    }
+
+    @Test
+    fun testSnapshotWithTagAndComponent() {
+        val world = configureWorld {}
+        val component = TestTagComponent()
+        val entity = world.entity {
+            it += TestTags.PLAYER
+            it += component
+        }
+
+        val snapshot = world.snapshotOf(entity)
+        assertEquals(TestTags.PLAYER, snapshot.tags[0])
+        assertEquals(component, snapshot.components[0])
+
+        world.removeAll(true)
+        with(world) {
+            assertFalse(entity has TestTags.PLAYER)
+            assertFalse(entity has TestTagComponent)
+
+            world.loadSnapshot(mapOf(entity to snapshot))
+
+            assertTrue(entity has TestTags.PLAYER)
+            assertTrue(entity has TestTagComponent)
         }
     }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -11,7 +11,7 @@ class TestTagSystem(var ticks: Int = 0) : IteratingSystem(family { all(Visible) 
     }
 }
 
-enum class TestTags : EntityTags by entityTagsOf() {
+enum class TestTags : EntityTags by entityTagOf() {
     PLAYER, COLLISION
 }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.*
 
 data object Visible : EntityTag()
 
-class TestTagSystem(var ticks: Int = 0) : IteratingSystem(family { all(Visible) }) {
+class TestTagSystem(var ticks: Int = 0) : IteratingSystem(family { all(Visible, TestTags.PLAYER) }) {
     override fun onTickEntity(entity: Entity) {
         ++ticks
     }
@@ -45,7 +45,10 @@ class EntityTagTest {
                 add(TestTagSystem().also { testSystem = it })
             }
         }
-        val entity = world.entity { it += Visible }
+        val entity = world.entity {
+            it += Visible
+            it += TestTags.PLAYER
+        }
 
         world.update(1f)
         assertEquals(1, testSystem.ticks)

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -20,7 +20,7 @@ class EntityTagTest {
     @Test
     fun testTagAssignment() {
         val world = configureWorld {}
-        val entity = world.entity { it[Visible] = true }
+        val entity = world.entity { it += Visible }
 
         with(world) {
             assertTrue(entity[Visible])
@@ -30,7 +30,9 @@ class EntityTagTest {
 //             assertTrue(entity has Visible) // <- compile error because Visible does not extend Component
 //             assertTrue(entity hasNo  Visible) // <- compile error because Visible does not extend Component
 
-            entity.configure { it[Visible] = false }
+            entity.configure {
+                it -= Visible
+            }
 
             assertFalse(entity[Visible])
         }
@@ -44,13 +46,13 @@ class EntityTagTest {
                 add(TestTagSystem().also { testSystem = it })
             }
         }
-        val entity = world.entity { it[Visible] = true }
+        val entity = world.entity { it += Visible }
 
         world.update(1f)
         assertEquals(1, testSystem.ticks)
 
         testSystem.ticks = 0
-        with(world) { entity.configure { it[Visible] = false } }
+        with(world) { entity.configure { it -= Visible } }
         world.update(1f)
         assertEquals(0, testSystem.ticks)
     }
@@ -62,12 +64,12 @@ class EntityTagTest {
         assertNotEquals(Visible.id, TestTags.COLLISION.id)
 
         val world = configureWorld {}
-        val entity = world.entity { it[TestTags.PLAYER] = true }
+        val entity = world.entity { it += TestTags.PLAYER }
 
         with(world) {
             assertTrue(entity[TestTags.PLAYER])
 
-            entity.configure { it[TestTags.PLAYER] = false }
+            entity.configure { it -= TestTags.PLAYER }
 
             assertFalse(entity[TestTags.PLAYER])
         }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-data object Visible : ComponentType<Visible>()
+data object Visible : EntityTag()
 
 class TestTagSystem(var ticks: Int = 0) : IteratingSystem(family { all(Visible) }) {
     override fun onTickEntity(entity: Entity) {
@@ -23,6 +23,11 @@ class EntityTagTest {
 
         with(world) {
             assertTrue(entity[Visible])
+            // entity.getOrNull(Visible) // <- compile error because Visible does not extend Component
+            // val cmp : Visible = entity[Visible] // <- compile error because Visible does not extend Component and therefore 'cmp' must be of type Boolean
+            // assertTrue(Visible in entity) // <- compile error because Visible does not extend Component
+            // assertTrue(entity has Visible) // <- compile error because Visible does not extend Component
+            // assertTrue(entity hasNo  Visible) // <- compile error because Visible does not extend Component
 
             entity.configure { it[Visible] = false }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -129,4 +129,29 @@ class EntityTagTest {
             assertTrue(entity has TestTagComponent)
         }
     }
+
+    @Test
+    fun testLoadSnapshotOfTag() {
+        val world = configureWorld {}
+        val entity = world.entity { }
+
+        world.loadSnapshot(mapOf(entity to Snapshot(emptyList(), listOf(TestTags.PLAYER))))
+
+        with(world) {
+            assertTrue(entity has TestTags.PLAYER)
+            assertTrue(TestTags.PLAYER.id in world.tagCache)
+        }
+    }
+
+    @Test
+    fun testSetListOfTags() {
+        val world = configureWorld {}
+        val entity = world.entity { it += TestTags.entries }
+
+        with(world) {
+            TestTags.entries.forEach {
+                assertTrue(it in entity)
+            }
+        }
+    }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -23,18 +23,11 @@ class EntityTagTest {
         val entity = world.entity { it += Visible }
 
         with(world) {
-            assertTrue(entity[Visible])
-//             entity.getOrNull(Visible) // <- compile error because Visible does not extend Component
-//             val cmp : Visible = entity[Visible] // <- compile error because Visible does not extend Component and therefore 'cmp' must be of type Boolean
-//             assertTrue(Visible in entity) // <- compile error because Visible does not extend Component
-//             assertTrue(entity has Visible) // <- compile error because Visible does not extend Component
-//             assertTrue(entity hasNo  Visible) // <- compile error because Visible does not extend Component
+            assertTrue(Visible in entity)
 
-            entity.configure {
-                it -= Visible
-            }
+            entity.configure { it -= Visible }
 
-            assertFalse(entity[Visible])
+            assertFalse(Visible in entity)
         }
     }
 
@@ -67,11 +60,11 @@ class EntityTagTest {
         val entity = world.entity { it += TestTags.PLAYER }
 
         with(world) {
-            assertTrue(entity[TestTags.PLAYER])
+            assertTrue(entity has TestTags.PLAYER)
 
             entity.configure { it -= TestTags.PLAYER }
 
-            assertFalse(entity[TestTags.PLAYER])
+            assertTrue(entity hasNo TestTags.PLAYER)
         }
     }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -1,10 +1,7 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.World.Companion.family
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 data object Visible : EntityTag()
 
@@ -12,6 +9,10 @@ class TestTagSystem(var ticks: Int = 0) : IteratingSystem(family { all(Visible) 
     override fun onTickEntity(entity: Entity) {
         ++ticks
     }
+}
+
+enum class TestTags : EntityTags by entityTagsOf() {
+    PLAYER, COLLISION
 }
 
 class EntityTagTest {
@@ -23,11 +24,11 @@ class EntityTagTest {
 
         with(world) {
             assertTrue(entity[Visible])
-            // entity.getOrNull(Visible) // <- compile error because Visible does not extend Component
-            // val cmp : Visible = entity[Visible] // <- compile error because Visible does not extend Component and therefore 'cmp' must be of type Boolean
-            // assertTrue(Visible in entity) // <- compile error because Visible does not extend Component
-            // assertTrue(entity has Visible) // <- compile error because Visible does not extend Component
-            // assertTrue(entity hasNo  Visible) // <- compile error because Visible does not extend Component
+//             entity.getOrNull(Visible) // <- compile error because Visible does not extend Component
+//             val cmp : Visible = entity[Visible] // <- compile error because Visible does not extend Component and therefore 'cmp' must be of type Boolean
+//             assertTrue(Visible in entity) // <- compile error because Visible does not extend Component
+//             assertTrue(entity has Visible) // <- compile error because Visible does not extend Component
+//             assertTrue(entity hasNo  Visible) // <- compile error because Visible does not extend Component
 
             entity.configure { it[Visible] = false }
 
@@ -52,5 +53,23 @@ class EntityTagTest {
         with(world) { entity.configure { it[Visible] = false } }
         world.update(1f)
         assertEquals(0, testSystem.ticks)
+    }
+
+    @Test
+    fun testEnumTags() {
+        assertNotEquals(TestTags.PLAYER.id, TestTags.COLLISION.id)
+        assertNotEquals(Visible.id, TestTags.PLAYER.id)
+        assertNotEquals(Visible.id, TestTags.COLLISION.id)
+
+        val world = configureWorld {}
+        val entity = world.entity { it[TestTags.PLAYER] = true }
+
+        with(world) {
+            assertTrue(entity[TestTags.PLAYER])
+
+            entity.configure { it[TestTags.PLAYER] = false }
+
+            assertFalse(entity[TestTags.PLAYER])
+        }
     }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -1,0 +1,51 @@
+package com.github.quillraven.fleks
+
+import com.github.quillraven.fleks.World.Companion.family
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+data object Visible : ComponentType<Visible>()
+
+class TestTagSystem(var ticks: Int = 0) : IteratingSystem(family { all(Visible) }) {
+    override fun onTickEntity(entity: Entity) {
+        ++ticks
+    }
+}
+
+class EntityTagTest {
+
+    @Test
+    fun testTagAssignment() {
+        val world = configureWorld {}
+        val entity = world.entity { it[Visible] = true }
+
+        with(world) {
+            assertTrue(entity[Visible])
+
+            entity.configure { it[Visible] = false }
+
+            assertFalse(entity[Visible])
+        }
+    }
+
+    @Test
+    fun testTagSystem() {
+        lateinit var testSystem: TestTagSystem
+        val world = configureWorld {
+            systems {
+                add(TestTagSystem().also { testSystem = it })
+            }
+        }
+        val entity = world.entity { it[Visible] = true }
+
+        world.update(1f)
+        assertEquals(1, testSystem.ticks)
+
+        testSystem.ticks = 0
+        with(world) { entity.configure { it[Visible] = false } }
+        world.update(1f)
+        assertEquals(0, testSystem.ticks)
+    }
+}


### PR DESCRIPTION
PR for #118 (WIP)

@LobbyDivinus : this is a very quick draft from my side. Basically, I just added two additional entity extension functions which should be sufficient to support tags. You can see the usage in the Test class.

The downside of this approach is that tag ids are part of component ids, meaning that they will be part of the normal component mask and "waste" space in the BitArray.

I haven't had a look at your fork yet. Will do that tomorrow!

----

TODO:
- [x] documentation
- [x] separate contains, has, hasNo extensions for tags
- [x] verify in example projects if this breaks something (everything must compile without doing any changes)
- [x] benchmarks: had no impact for me. I was a little concerned about the introduction of the `UniqueId` interface but seems to have no extra overhead or impact
- [x] (**not part of this PR because this is not so easy to fix**) check if `EntityComponentContext` can be refactored a little bit to avoid `componentService.world.entityService` calls