### PR TITLE
update to Kotlin 1.9.20

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,10 +1,10 @@
 # Fleks
 
 [![LTS](https://img.shields.io/badge/LTS-2.5-orange.svg)](https://search.maven.org/artifact/io.github.quillraven.fleks/Fleks/2.5/jar)
-[![Snapshot](https://img.shields.io/badge/Snapshot-2.5--SNAPSHOT-orange.svg)](https://s01.oss.sonatype.org/#nexus-search;gav~io.github.quillraven.fleks~~2.5-SNAPSHOT~~)
+[![Snapshot](https://img.shields.io/badge/Snapshot-2.6--SNAPSHOT-orange.svg)](https://s01.oss.sonatype.org/#nexus-search;gav~io.github.quillraven.fleks~~2.6-SNAPSHOT~~)
 
 [![Build Master](https://img.shields.io/github/actions/workflow/status/quillraven/fleks/build.yml?branch=master)](https://github.com/Quillraven/fleks/actions)
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.9.10-red.svg)](http://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.9.20-red.svg)](http://kotlinlang.org/)
 
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Quillraven/Fleks/blob/master/LICENSE)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.quillraven.fleks"
-version = "2.5"
+version = "2.6-SNAPSHOT"
 
 kotlin {
     jvm {

--- a/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-js.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-js.gradle.kts
@@ -7,10 +7,8 @@ plugins {
 }
 
 kotlin {
-    targets {
-        js(IR) {
-            browser()
-            nodejs()
-        }
+    js(IR) {
+        browser()
+        nodejs()
     }
 }

--- a/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-native.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-native.gradle.kts
@@ -1,8 +1,5 @@
 package buildsrc.plugins
 
-import org.gradle.kotlin.dsl.creating
-import org.gradle.kotlin.dsl.getting
-
 /** conventions for a Kotlin/Native subproject */
 
 plugins {
@@ -33,8 +30,7 @@ kotlin {
     //         ├── watchosX64
     //         └── watchosSimulatorArm64Main
     //
-    // More specialised targets are disabled. They can be enabled, if there is demand for them - just make sure
-    // to add `dependsOn(nativeMain)` / `dependsOn(nativeTest)` below for any new targets.
+    // More specialised targets are disabled. They can be enabled, if there is demand for them.
 
     linuxX64()
     linuxArm64()
@@ -57,30 +53,4 @@ kotlin {
     //androidNativeX86()
     //androidNativeX64()
     //watchosDeviceArm64()
-
-    @Suppress("UNUSED_VARIABLE")
-    sourceSets {
-        val commonMain by getting {}
-        val commonTest by getting {}
-
-        val nativeMain by creating { dependsOn(commonMain) }
-        val nativeTest by creating { dependsOn(commonTest) }
-
-        // Linux
-        val linuxX64Main by getting { dependsOn(nativeMain) }
-        val linuxX64Test by getting { dependsOn(nativeTest) }
-        val linuxArm64Main by getting { dependsOn(nativeMain) }
-        val linuxArm64Test by getting { dependsOn(nativeTest) }
-
-        // Windows - MinGW
-        val mingwX64Main by getting { dependsOn(nativeMain) }
-        val mingwX64Test by getting { dependsOn(nativeTest) }
-
-        // Apple - macOS
-        val macosArm64Main by getting { dependsOn(nativeMain) }
-        val macosArm64Test by getting { dependsOn(nativeTest) }
-
-        val macosX64Main by getting { dependsOn(nativeMain) }
-        val macosX64Test by getting { dependsOn(nativeTest) }
-    }
 }

--- a/buildSrc/src/main/kotlin/buildsrc/plugins/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/plugins/publishing.gradle.kts
@@ -21,15 +21,15 @@ plugins {
 //region Publication Properties
 // can be set in `$GRADLE_USER_HOME/gradle.properties`, e.g. `fleks.ossrhPassword=123`
 // or environment variables, e.g. `ORG_GRADLE_PROJECT_fleks.ossrhUsername=abc`
-val ossrhUsername = providers.gradleProperty("fleks.ossrhUsername")
-val ossrhPassword = providers.gradleProperty("fleks.ossrhPassword")
+val ossrhUsername: Provider<String> = providers.gradleProperty("fleks.ossrhUsername")
+val ossrhPassword: Provider<String> = providers.gradleProperty("fleks.ossrhPassword")
 
-val signingKey = providers.gradleProperty("fleks.signing.key")
-val signingPassword = providers.gradleProperty("fleks.signing.password")
+val signingKey: Provider<String> = providers.gradleProperty("fleks.signing.key")
+val signingPassword: Provider<String> = providers.gradleProperty("fleks.signing.password")
 
 val isReleaseVersion = provider { !version.toString().endsWith("-SNAPSHOT") }
 
-val sonatypeReleaseUrl = isReleaseVersion.map { isRelease ->
+val sonatypeReleaseUrl: Provider<String> = isReleaseVersion.map { isRelease ->
     if (isRelease) {
         "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
     } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-kotlin = "1.9.10"
+kotlin = "1.9.20"
 kotlinxSerialization = "1.6.0"
 kotlinDokka = "1.9.10"
 kotlinxBenchmark = "0.4.9"


### PR DESCRIPTION
Updates Kotlin to 1.9.20. This also includes some gradle file updates because they improved the KMP setup and simplified certain things. From my understanding there is a default "KMP template" now in the background with the typical sourceset structure and therefore the custom configuration from before is no longer necessary like all the `dependsOn` calls.