### PR TITLE
#125: optimize EntityTag syntax

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -2,6 +2,7 @@ package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.*
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmName
 
 /**
  * An entity of a [world][World]. It represents a unique identifier that is the combination
@@ -152,6 +153,7 @@ open class EntityCreateContext(
     /**
      * Sets all [tags][EntityTag] on the given [entity][Entity].
      */
+    @JvmName("plusAssignTags")
     operator fun Entity.plusAssign(tags: List<EntityTags>) {
         tags.forEach { this += it }
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/entity.kt
@@ -2,7 +2,6 @@ package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.*
 import kotlinx.serialization.Serializable
-import kotlin.jvm.JvmName
 
 /**
  * An entity of a [world][World]. It represents a unique identifier that is the combination
@@ -141,7 +140,7 @@ open class EntityCreateContext(
     /**
      * Sets the [tag][EntityTag] to the [entity][Entity].
      */
-    operator fun Entity.plusAssign(tag: UniqueId<*>) {
+    operator fun Entity.plusAssign(tag: EntityTags) {
         compMasks[this.id].set(tag.id)
         // We need to remember used tags in order to correctly return and load them using
         // the snapshot functionality, because tags are not managed via ComponentHolder and
@@ -153,8 +152,7 @@ open class EntityCreateContext(
     /**
      * Sets all [tags][EntityTag] on the given [entity][Entity].
      */
-    @JvmName("plusAssignTags")
-    operator fun Entity.plusAssign(tags: List<UniqueId<*>>) {
+    operator fun Entity.plusAssign(tags: List<EntityTags>) {
         tags.forEach { this += it }
     }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -154,4 +154,22 @@ class EntityTagTest {
             }
         }
     }
+
+    /*
+    fun syntaxCheck() {
+        val world = configureWorld {}
+        world.entity {
+            it += TestTags.PLAYER
+            it += Visible
+            it += listOf(Visible)
+            it += TestTags.entries
+            it += listOf(Visible, TestTags.PLAYER)
+
+            it += TestTagComponent()
+            it += listOf(TestTagComponent())
+
+            it += TestTagComponent // <-- should not compile
+        }
+    }
+     */
 }


### PR DESCRIPTION
This should solve the problem that users can write `entity += Component` which is wrong. Components must always be assigned with a specific instance.

The issue was introduced with the `EntityTag` functionality.