### PR TITLE
#124: add onEnabled/onDisabled functions to IntervalSystem

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -30,12 +30,22 @@ data class Fixed(val step: Float) : Interval
  */
 abstract class IntervalSystem(
     val interval: Interval = EachFrame,
-    var enabled: Boolean = true,
+    enabled: Boolean = true,
     /**
      * Returns the [world][World] to which this system belongs.
      */
     val world: World = World.CURRENT_WORLD ?: throw FleksWrongConfigurationUsageException()
 ) : EntityComponentContext(world.componentService) {
+
+    var enabled: Boolean = enabled
+        set(value) {
+            if (value) {
+                onEnabled()
+            } else {
+                onDisabled()
+            }
+            field = value
+        }
 
     private var accumulator: Float = 0.0f
 
@@ -48,6 +58,16 @@ abstract class IntervalSystem(
      */
     val deltaTime: Float
         get() = if (interval is Fixed) interval.step else world.deltaTime
+
+    /**
+     * This function gets called whenever the system gets [enabled].
+     */
+    open fun onEnabled() = Unit
+
+    /**
+     * This function gets called whenever the system gets [disabled][enabled].
+     */
+    open fun onDisabled() = Unit
 
     /**
      * Updates the system according to its [interval]. This function gets called from [World.update] when

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -39,12 +39,16 @@ abstract class IntervalSystem(
 
     var enabled: Boolean = enabled
         set(value) {
-            if (value) {
-                onEnabled()
-            } else {
-                onDisabled()
+            if (value == field) {
+                return
             }
+
             field = value
+            if (value) {
+                onEnable()
+            } else {
+                onDisable()
+            }
         }
 
     private var accumulator: Float = 0.0f
@@ -62,12 +66,12 @@ abstract class IntervalSystem(
     /**
      * This function gets called whenever the system gets [enabled].
      */
-    open fun onEnabled() = Unit
+    open fun onEnable() = Unit
 
     /**
      * This function gets called whenever the system gets [disabled][enabled].
      */
-    open fun onDisabled() = Unit
+    open fun onDisable() = Unit
 
     /**
      * Updates the system according to its [interval]. This function gets called from [World.update] when

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
@@ -156,6 +156,21 @@ private class SystemTestIteratingSystemQualifiedInjectable(
     override fun onTickEntity(entity: Entity) = Unit
 }
 
+private class SystemTestEnable(enabled: Boolean) : IntervalSystem(enabled = enabled) {
+    var enabledCall = false
+    var disabledCall = false
+
+    override fun onEnabled() {
+        enabledCall = true
+    }
+
+    override fun onDisabled() {
+        disabledCall = true
+    }
+
+    override fun onTick() = Unit
+}
+
 internal class SystemTest {
     @Test
     fun systemWithIntervalEachFrameGetsCalledEveryTime() {
@@ -430,5 +445,27 @@ internal class SystemTest {
 
         val system = world.system<SystemTestEntityCreation>()
         assertEquals(1, system.numTicks)
+    }
+
+    @Test
+    fun testOnEnabledDisabled() {
+        val world = configureWorld {
+            systems {
+                add(SystemTestEnable(false))
+            }
+        }
+        val system = world.system<SystemTestEnable>()
+
+        assertFalse(system.enabledCall)
+        assertFalse(system.disabledCall)
+
+        system.enabled = true
+        assertTrue(system.enabledCall)
+        assertFalse(system.disabledCall)
+        system.enabledCall = false
+
+        system.enabled = false
+        assertFalse(system.enabledCall)
+        assertTrue(system.disabledCall)
     }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
@@ -160,11 +160,11 @@ private class SystemTestEnable(enabled: Boolean) : IntervalSystem(enabled = enab
     var enabledCall = false
     var disabledCall = false
 
-    override fun onEnabled() {
+    override fun onEnable() {
         enabledCall = true
     }
 
-    override fun onDisabled() {
+    override fun onDisable() {
         disabledCall = true
     }
 
@@ -460,12 +460,27 @@ internal class SystemTest {
         assertFalse(system.disabledCall)
 
         system.enabled = true
+        assertTrue(system.enabled)
         assertTrue(system.enabledCall)
         assertFalse(system.disabledCall)
         system.enabledCall = false
 
         system.enabled = false
+        assertFalse(system.enabled)
         assertFalse(system.enabledCall)
         assertTrue(system.disabledCall)
+        system.disabledCall = false
+
+        // should not call methods when value does not change
+        system.enabled = false
+        assertFalse(system.enabledCall)
+        assertFalse(system.disabledCall)
+
+        system.enabled = true
+        system.enabledCall = false
+        system.disabledCall = false
+        system.enabled = true
+        assertFalse(system.enabledCall)
+        assertFalse(system.disabledCall)
     }
 }


### PR DESCRIPTION
PR for #124

@metaphore: Are you fine with that change? I am wondering, if we should call onEnabled/onDisabled also when a system gets created. I mean that we explicitly set it on the constructor (=`init`) block of an IteratingSystem to trigger those functions initially. But I am not 100% sure if this is a good idea. Maybe it is better to really just trigger them, when setEnabled is explicitly called by the user. What do you think?