### PR TITLE
#129 reverse system dispose and entity onRemove order.

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -234,9 +234,9 @@ class WorldConfiguration(@PublishedApi internal val world: World) {
                 val systemArray = systemList.toTypedArray()
                 family.removeHook = if (ownHook != null) { entity ->
                     ownHook(world, entity)
-                    systemArray.forEach { it.onRemoveEntity(entity) }
+                    systemArray.forEachReverse { it.onRemoveEntity(entity) }
                 } else { entity ->
-                    systemArray.forEach { it.onRemoveEntity(entity) }
+                    systemArray.forEachReverse { it.onRemoveEntity(entity) }
                 }
             }
     }
@@ -633,7 +633,7 @@ class World internal constructor(
      */
     fun dispose() {
         entityService.removeAll()
-        systems.forEach { it.onDispose() }
+        systems.forEachReverse { it.onDispose() }
     }
 
 
@@ -667,5 +667,12 @@ class World internal constructor(
          */
         fun family(cfg: FamilyDefinition.() -> Unit): Family =
             CURRENT_WORLD?.family(cfg) ?: throw FleksWrongConfigurationUsageException()
+    }
+}
+
+private inline fun <T> Array<T>.forEachReverse(action: (T) -> Unit) {
+    val lastIndex = this.lastIndex
+    for (i in lastIndex downTo 0) {
+        action(this[i])
     }
 }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/SystemOrderTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/SystemOrderTest.kt
@@ -1,0 +1,172 @@
+package com.github.quillraven.fleks
+
+import com.github.quillraven.fleks.World.Companion.family
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private class TestComponent : Component<TestComponent> {
+    companion object : ComponentType<TestComponent>()
+    override fun type() = TestComponent
+}
+
+private abstract class BaseSystem(
+    val onInitOrder: MutableList<BaseSystem> = mutableListOf(),
+    val onUpdateOrder: MutableList<BaseSystem> = mutableListOf(),
+    val onDisposeOrder: MutableList<BaseSystem> = mutableListOf(),
+    val onAddEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+    val onTickEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+    val onRemoveEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+) : IteratingSystem(
+    family { all (TestComponent) }
+), FamilyOnAdd, FamilyOnRemove {
+
+    override fun onInit() {
+        super.onInit()
+        onInitOrder += this
+    }
+
+    override fun onUpdate() {
+        super.onUpdate()
+        onUpdateOrder += this
+    }
+
+    override fun onDispose() {
+        super.onDispose()
+        onDisposeOrder += this
+    }
+
+    override fun onAddEntity(entity: Entity) {
+        onAddEntityOrder += this
+    }
+
+    override fun onTickEntity(entity: Entity) {
+        onTickEntityOrder += this
+    }
+
+    override fun onRemoveEntity(entity: Entity) {
+        onRemoveEntityOrder += this
+    }
+}
+
+private class FirstSystem(
+    onInitOrder: MutableList<BaseSystem> = mutableListOf(),
+    onUpdateOrder: MutableList<BaseSystem> = mutableListOf(),
+    onDisposeOrder: MutableList<BaseSystem> = mutableListOf(),
+    onAddEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+    onTickEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+    onRemoveEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+) : BaseSystem(onInitOrder, onUpdateOrder, onDisposeOrder, onAddEntityOrder, onTickEntityOrder, onRemoveEntityOrder)
+
+private class SecondSystem(
+    onInitOrder: MutableList<BaseSystem> = mutableListOf(),
+    onUpdateOrder: MutableList<BaseSystem> = mutableListOf(),
+    onDisposeOrder: MutableList<BaseSystem> = mutableListOf(),
+    onAddEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+    onTickEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+    onRemoveEntityOrder: MutableList<BaseSystem> = mutableListOf(),
+) : BaseSystem(onInitOrder, onUpdateOrder, onDisposeOrder, onAddEntityOrder, onTickEntityOrder, onRemoveEntityOrder)
+
+internal class SystemOrderTest {
+
+    @Test
+    fun onInit() {
+        val systemOrder = mutableListOf<BaseSystem>()
+
+        configureWorld {
+            systems {
+                add(FirstSystem(onInitOrder = systemOrder))
+                add(SecondSystem(onInitOrder = systemOrder))
+            }
+        }
+
+        assertEquals(FirstSystem::class, systemOrder[0]::class)
+        assertEquals(SecondSystem::class, systemOrder[1]::class)
+    }
+
+    @Test
+    fun onUpdate() {
+        val systemOrder = mutableListOf<BaseSystem>()
+
+        val world = configureWorld {
+            systems {
+                add(FirstSystem(onUpdateOrder = systemOrder))
+                add(SecondSystem(onUpdateOrder = systemOrder))
+            }
+        }
+
+        world.update(0f)
+
+        assertEquals(FirstSystem::class, systemOrder[0]::class)
+        assertEquals(SecondSystem::class, systemOrder[1]::class)
+    }
+
+    @Test
+    fun onDispose() {
+        val systemOrder = mutableListOf<BaseSystem>()
+
+        val world = configureWorld {
+            systems {
+                add(FirstSystem(onDisposeOrder = systemOrder))
+                add(SecondSystem(onDisposeOrder = systemOrder))
+            }
+        }
+
+        world.dispose()
+
+        assertEquals(SecondSystem::class, systemOrder[0]::class)
+        assertEquals(FirstSystem::class, systemOrder[1]::class)
+    }
+
+    @Test
+    fun onAddEntity() {
+        val systemOrder = mutableListOf<BaseSystem>()
+
+        val world = configureWorld {
+            systems {
+                add(FirstSystem(onAddEntityOrder = systemOrder))
+                add(SecondSystem(onAddEntityOrder = systemOrder))
+            }
+        }
+
+        world.entity { it += TestComponent() }
+
+        assertEquals(FirstSystem::class, systemOrder[0]::class)
+        assertEquals(SecondSystem::class, systemOrder[1]::class)
+    }
+
+    @Test
+    fun onTickEntity() {
+        val systemOrder = mutableListOf<BaseSystem>()
+
+        val world = configureWorld {
+            systems {
+                add(FirstSystem(onTickEntityOrder = systemOrder))
+                add(SecondSystem(onTickEntityOrder = systemOrder))
+            }
+        }
+
+        world.entity { it += TestComponent() }
+        world.update(0f)
+
+        assertEquals(FirstSystem::class, systemOrder[0]::class)
+        assertEquals(SecondSystem::class, systemOrder[1]::class)
+    }
+
+    @Test
+    fun onRemoveEntity() {
+        val systemOrder = mutableListOf<BaseSystem>()
+
+        val world = configureWorld {
+            systems {
+                add(FirstSystem(onRemoveEntityOrder = systemOrder))
+                add(SecondSystem(onRemoveEntityOrder = systemOrder))
+            }
+        }
+
+        val entity = world.entity { it += TestComponent() }
+        world -= entity
+
+        assertEquals(SecondSystem::class, systemOrder[0]::class)
+        assertEquals(FirstSystem::class, systemOrder[1]::class)
+    }
+}


### PR DESCRIPTION
Follow up for #129

- Call system dispose in reverse order
- Call `FamilyOnRemove.onRemove(entity: Entity)` in reverse order (depends on the bound system).
- Dedicated tests for system execution order.

I'm not sure what's the best way to do a reverse "for" loop on an array in Kotlin. Sounds like there's no built-in singular function for that, and I didn't want to use something that may create an iterator or do unnecessary allocation like `collection.asReversed().forEach()`. So I added an inline extension function `forEachReversed()` at the end of the `world.kt` file. Don't know if there's any better place.

@Quillraven please let me know if there's something wrong with it and if it needs to be changed/moved.