### PR TITLE
Make iterating system private sorting-related fields protected.

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -133,7 +133,7 @@ abstract class IntervalSystem(
  * [Automatic] means that the sorting of [entities][Entity] is happening automatically each time
  * [IteratingSystem.onTick] gets called.
  *
- * [Manual] means that sorting must be called programmatically by setting [IteratingSystem.doSort] to true.
+ * [Manual] means that sorting must be called programmatically by setting [IteratingSystem.onSort] to true.
  * [Entities][Entity] are then sorted the next time [IteratingSystem.onTick] gets called.
  */
 sealed interface SortingType
@@ -172,14 +172,21 @@ abstract class IteratingSystem(
     var doSort = sortingType == Automatic && comparator != EMPTY_COMPARATOR
 
     /**
-     * Updates the [family] if needed and calls [onTickEntity] for each [entity][Entity] of the [family].
      * If [doSort] is true then [entities][Entity] are sorted using the [comparator] before calling [onTickEntity].
      */
-    override fun onTick() {
+    open fun onSort() {
         if (doSort) {
             doSort = sortingType == Automatic
             family.sort(comparator)
         }
+    }
+
+    /**
+     * Updates the [family] if needed and calls [onTickEntity] for each [entity][Entity] of the [family].
+     * Does entity sorting using [onSort] before calling [onTickEntity].
+     */
+    override fun onTick() {
+        onSort()
 
         family.forEach { onTickEntity(it) }
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -157,8 +157,8 @@ data object Manual : SortingType
  */
 abstract class IteratingSystem(
     val family: Family,
-    private val comparator: EntityComparator = EMPTY_COMPARATOR,
-    private val sortingType: SortingType = Automatic,
+    protected val comparator: EntityComparator = EMPTY_COMPARATOR,
+    protected val sortingType: SortingType = Automatic,
     interval: Interval = EachFrame,
     enabled: Boolean = true
 ) : IntervalSystem(interval, enabled) {

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -133,7 +133,7 @@ abstract class IntervalSystem(
  * [Automatic] means that the sorting of [entities][Entity] is happening automatically each time
  * [IteratingSystem.onTick] gets called.
  *
- * [Manual] means that sorting must be called programmatically by setting [IteratingSystem.onSort] to true.
+ * [Manual] means that sorting must be called programmatically by setting [IteratingSystem.doSort] to true.
  * [Entities][Entity] are then sorted the next time [IteratingSystem.onTick] gets called.
  */
 sealed interface SortingType


### PR DESCRIPTION
Here's a small change that allows for fully custom `IteratingSystem.onTick()` implementations.

It happened so I needed to modify the entity processing flow of the `IteratingSystem` by inserting one extra call right after the sorting is done and before the entity iteration. Like this:
```kotlin
override fun onTick() {
        if (doSort) {
            doSort = sortingType == Automatic
            family.sort(comparator)
        }
        
        // Do something here.

        family.forEach { onTickEntity(it) }
}
```

But it turns out, that I cannot fully replicate the original logic as the sorting-related fields are private.