### PR TITLE
add wasm platform (kotlin -> 1.9.24)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,11 @@ kotlin {
     }
 
     sourceSets {
+        all {
+            // WASM: for bitArray.kt Long::countLeadingZeroBits
+            languageSettings.optIn("kotlin.ExperimentalStdlibApi")
+        }
+
         commonMain {
             dependencies {
                 implementation(libs.kotlinxSerialization.json)

--- a/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-js.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-js.gradle.kts
@@ -1,7 +1,6 @@
 package buildsrc.plugins
 
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 /** conventions for a Kotlin/JS subproject */
 
@@ -15,19 +14,9 @@ kotlin {
         nodejs()
     }
 
+    @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()
         nodejs()
     }
-}
-
-// https://youtrack.jetbrains.com/issue/KT-63014/
-// CompileError: WebAssembly.Module(): invalid value type 0x71
-rootProject.the<NodeJsRootExtension>().apply {
-    nodeVersion = "21.0.0-v8-canary202309143a48826a08"
-    nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
-    download = false
-}
-tasks.withType<KotlinNpmInstallTask>().configureEach {
-    args.add("--ignore-engines")
 }

--- a/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-js.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/plugins/kmp-js.gradle.kts
@@ -1,5 +1,8 @@
 package buildsrc.plugins
 
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
+
 /** conventions for a Kotlin/JS subproject */
 
 plugins {
@@ -11,4 +14,20 @@ kotlin {
         browser()
         nodejs()
     }
+
+    wasmJs {
+        browser()
+        nodejs()
+    }
+}
+
+// https://youtrack.jetbrains.com/issue/KT-63014/
+// CompileError: WebAssembly.Module(): invalid value type 0x71
+rootProject.the<NodeJsRootExtension>().apply {
+    nodeVersion = "21.0.0-v8-canary202309143a48826a08"
+    nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
+    download = false
+}
+tasks.withType<KotlinNpmInstallTask>().configureEach {
+    args.add("--ignore-engines")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-kotlin = "1.9.23"
+kotlin = "1.9.24"
 kotlinxSerialization = "1.6.3"
 kotlinDokka = "1.9.20"
 kotlinxBenchmark = "0.4.10"

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -144,7 +144,7 @@ internal class ComponentTest {
 
     @Test
     fun getHolderByComponentId() {
-        val actual = testService.holderByIndexOrNull(0)
+        val actual = testService.holderByIndexOrNull(ComponentTestComponent.id)
 
         assertSame(testHolder, actual)
     }


### PR DESCRIPTION
Trying to add WASM support but seems to be poorly documented and several YouTrack issues opened. From what I know it is still experimental but should be stable with Kotlin 2.0?

Anyway, it is a WIP and I think I resolved all issues except this one:

```
node: bad option: --experimental-wasm-gc
```

From what I understand this flag is no longer needed since it is automatically part of NodeJS? [YouTrack issue](https://youtrack.jetbrains.com/issue/KT-67785/Kotlin-Wasm-Node.JS-22-does-not-need-experimental-wasm-gc-flag-anymore)

So let's wait for Kotlin 2.0 and see if that solves the problem.

In addition, I hope that Kotlin 2.0 also solves following [issue](https://youtrack.jetbrains.com/issue/KT-63014/). We can then remove the part in `kmp-js.gradle.kts`.

Finally, I had to add this in `build.gradle.kts` in root:

```
all {
            // WASM: for bitArray.kt Long::countLeadingZeroBits
            languageSettings.optIn("kotlin.ExperimentalStdlibApi")
        }
```

Maybe that is also not necessary with Kotlin 2.0.

Let's see :)