### PR TITLE
new partition and partitionTo function for entity bag

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/collection/entityBag.kt
@@ -63,9 +63,7 @@ interface EntityBag {
      * Returns a [Map] containing the [entities][Entity] of the bag indexed by the key
      * returned from [keySelector] function applied to each [entity][Entity] of the bag.
      */
-    fun <K> associateBy(
-        keySelector: (Entity) -> K
-    ): Map<K, Entity>
+    fun <K> associateBy(keySelector: (Entity) -> K): Map<K, Entity>
 
     /**
      * Returns a [Map] containing the values provided by [valueTransform] and indexed by the
@@ -143,14 +141,16 @@ interface EntityBag {
      * Appends all [entities][Entity] not matching the given [predicate] to the given [destination].
      */
     fun filterNotTo(
-        destination: MutableEntityBag, predicate: (Entity) -> Boolean
+        destination: MutableEntityBag,
+        predicate: (Entity) -> Boolean
     ): MutableEntityBag
 
     /**
      * Appends all [entities][Entity] matching the given [predicate] to the given [destination].
      */
     fun filterIndexedTo(
-        destination: MutableEntityBag, predicate: (index: Int, Entity) -> Boolean
+        destination: MutableEntityBag,
+        predicate: (index: Int, Entity) -> Boolean
     ): MutableEntityBag
 
     /**
@@ -338,6 +338,24 @@ interface EntityBag {
         destination: C,
         transform: (Entity) -> R?
     ): C
+
+    /**
+     * Splits the original bag into a pair of bags,
+     * where the first bag contains elements for which predicate yielded true,
+     * while the second bag contains elements for which predicate yielded false.
+     */
+    fun partition(predicate: (Entity) -> Boolean): Pair<EntityBag, EntityBag>
+
+    /**
+     * Splits the original bag into two bags,
+     * where [first] contains elements for which predicate yielded true,
+     * while [second] contains elements for which predicate yielded false.
+     */
+    fun partitionTo(
+        first: MutableEntityBag,
+        second: MutableEntityBag,
+        predicate: (Entity) -> Boolean
+    )
 
     /**
      * Returns a random [entity][Entity] of the bag.
@@ -537,7 +555,10 @@ class MutableEntityBag(
      * Returns a [Map] containing the values provided by [valueTransform] and indexed by the
      * [keySelector] function applied to each [entity][Entity] of the bag.
      */
-    override inline fun <K, V> associateBy(keySelector: (Entity) -> K, valueTransform: (Entity) -> V): Map<K, V> {
+    override inline fun <K, V> associateBy(
+        keySelector: (Entity) -> K,
+        valueTransform: (Entity) -> V
+    ): Map<K, V> {
         val result = mutableMapOf<K, V>()
         for (i in 0 until size) {
             val entity = values[i]
@@ -565,7 +586,10 @@ class MutableEntityBag(
      * of the bag indexed by the key returned from [keySelector] function applied to
      * each [entity][Entity] of the bag.
      */
-    override inline fun <K, M : MutableMap<in K, Entity>> associateByTo(destination: M, keySelector: (Entity) -> K): M {
+    override inline fun <K, M : MutableMap<in K, Entity>> associateByTo(
+        destination: M,
+        keySelector: (Entity) -> K
+    ): M {
         for (i in 0 until size) {
             val entity = values[i]
             destination[keySelector(entity)] = entity
@@ -653,7 +677,10 @@ class MutableEntityBag(
     /**
      * Appends all [entities][Entity] matching the given [predicate] to the given [destination].
      */
-    override inline fun filterTo(destination: MutableEntityBag, predicate: (Entity) -> Boolean): MutableEntityBag {
+    override inline fun filterTo(
+        destination: MutableEntityBag,
+        predicate: (Entity) -> Boolean
+    ): MutableEntityBag {
         for (i in 0 until size) {
             val entity = values[i]
             if (predicate(entity)) {
@@ -666,7 +693,10 @@ class MutableEntityBag(
     /**
      * Appends all [entities][Entity] not matching the given [predicate] to the given [destination].
      */
-    override inline fun filterNotTo(destination: MutableEntityBag, predicate: (Entity) -> Boolean): MutableEntityBag {
+    override inline fun filterNotTo(
+        destination: MutableEntityBag,
+        predicate: (Entity) -> Boolean
+    ): MutableEntityBag {
         for (i in 0 until size) {
             val entity = values[i]
             if (!predicate(entity)) {
@@ -826,7 +856,10 @@ class MutableEntityBag(
      * Accumulates value starting with [initial] value and applying [operation] from left to right to
      * current accumulator value and each [entity][Entity].
      */
-    override inline fun <R> fold(initial: R, operation: (acc: R, entity: Entity) -> R): R {
+    override inline fun <R> fold(
+        initial: R,
+        operation: (acc: R, entity: Entity) -> R
+    ): R {
         var accumulator = initial
         for (i in 0 until size) {
             accumulator = operation(accumulator, values[i])
@@ -838,7 +871,10 @@ class MutableEntityBag(
      * Accumulates value starting with [initial] value and applying [operation] from left to right to
      * current accumulator value and each [entity][Entity] with its index in the original bag.
      */
-    override inline fun <R> foldIndexed(initial: R, operation: (index: Int, acc: R, entity: Entity) -> R): R {
+    override inline fun <R> foldIndexed(
+        initial: R,
+        operation: (index: Int, acc: R, entity: Entity) -> R
+    ): R {
         var accumulator = initial
         for (i in 0 until size) {
             accumulator = operation(i, accumulator, values[i])
@@ -895,7 +931,10 @@ class MutableEntityBag(
      * by the key returned by the given [keySelector] function applied to the [entity][Entity] and returns
      * a map where each group key is associated with a list of corresponding values.
      */
-    override inline fun <K, V> groupBy(keySelector: (Entity) -> K, valueTransform: (Entity) -> V): Map<K, List<V>> {
+    override inline fun <K, V> groupBy(
+        keySelector: (Entity) -> K,
+        valueTransform: (Entity) -> V
+    ): Map<K, List<V>> {
         val result = mutableMapOf<K, MutableList<V>>()
         for (i in 0 until size) {
             val entity = values[i]
@@ -968,7 +1007,10 @@ class MutableEntityBag(
      * Applies the given [transform] function to each [entity][Entity] of the bag and appends
      * the results to the given [destination].
      */
-    override inline fun <R, C : MutableCollection<in R>> mapTo(destination: C, transform: (Entity) -> R): C {
+    override inline fun <R, C : MutableCollection<in R>> mapTo(
+        destination: C,
+        transform: (Entity) -> R
+    ): C {
         for (i in 0 until size) {
             destination += transform(values[i])
         }
@@ -1006,12 +1048,56 @@ class MutableEntityBag(
      * Applies the given [transform] function to each [entity][Entity] of the bag and appends only
      * the non-null results to the given [destination].
      */
-    override inline fun <R, C : MutableCollection<in R>> mapNotNullTo(destination: C, transform: (Entity) -> R?): C {
+    override inline fun <R, C : MutableCollection<in R>> mapNotNullTo(
+        destination: C,
+        transform: (Entity) -> R?
+    ): C {
         for (i in 0 until size) {
             val transformVal = transform(values[i]) ?: continue
             destination += transformVal
         }
         return destination
+    }
+
+    /**
+     * Splits the original bag into a pair of lists,
+     * where first list contains elements for which predicate yielded true,
+     * while second list contains elements for which predicate yielded false.
+     */
+    override inline fun partition(predicate: (Entity) -> Boolean): Pair<EntityBag, EntityBag> {
+        val first = MutableEntityBag()
+        val second = MutableEntityBag()
+        for (i in 0 until size) {
+            val entity = values[i]
+            if (predicate(entity)) {
+                first += entity
+            } else {
+                second += entity
+            }
+        }
+        return Pair(first, second)
+    }
+
+    /**
+     * Splits the original bag into two lists,
+     * where [first] contains elements for which predicate yielded true,
+     * while [second] contains elements for which predicate yielded false.
+     */
+    override inline fun partitionTo(
+        first: MutableEntityBag,
+        second: MutableEntityBag,
+        predicate: (Entity) -> Boolean
+    ) {
+        first.clear()
+        second.clear()
+        for (i in 0 until size) {
+            val entity = values[i]
+            if (predicate(entity)) {
+                first += entity
+            } else {
+                second += entity
+            }
+        }
     }
 
     /**

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/ComponentTest.kt
@@ -144,7 +144,7 @@ internal class ComponentTest {
 
     @Test
     fun getHolderByComponentId() {
-        val actual = testService.holderByIndexOrNull(0)
+        val actual = testService.holderByIndexOrNull(ComponentTestComponent.id)
 
         assertSame(testHolder, actual)
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityBagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/collection/EntityBagTest.kt
@@ -557,6 +557,29 @@ class EntityBagTest {
     }
 
     @Test
+    fun testPartition() {
+        val (first, second) = testBag.partition { it.id <= 0 }
+
+        assertEquals(1, first.size)
+        assertEquals(1, second.size)
+        assertTrue(testEntity1 in first)
+        assertTrue(testEntity2 in second)
+    }
+
+    @Test
+    fun testPartitionTo() {
+        val first = MutableEntityBag()
+        val second = MutableEntityBag()
+
+        testBag.partitionTo(first, second) { it.id <= 0 }
+
+        assertEquals(1, first.size)
+        assertEquals(1, second.size)
+        assertTrue(testEntity1 in first)
+        assertTrue(testEntity2 in second)
+    }
+
+    @Test
     fun testRandom() {
         val actual = testBag.random()
 


### PR DESCRIPTION
also fixes a test that breaks with wasm (ComponentHolderById). Looks like in the WASM tests the id of the component was 2 instead of 0. Using the component's real ID is anyway cleaner.

----

This PR was created to simplify a certain problem that I faced in QuillyJumper for the render system. I needed to iterate over an index of entities of a family in the render system (background entities, normal entities and foreground entities).

Between those entity render calls I also had the tiledmap render calls. I solved it by simply introducing entity tags and tag background and foreground entities with a bgd and fgd tag. The RenderSystem then had three separate families for foreground, normal and background entities.

While that worked, I did not like it a lot.
Giving a family the possibility to iterate from index A to index B might also not be that useful and maybe even tricky to implement (not sure).

That's why I came up with the idea to use the partition function of Kotlin (which actually could also be solved by using filter calls e.g.).
The new solution to my RenderSystem now is to have just one family of entities, sort them at the beginning of the system's onTick function (=normal behavior = good :) ) and then split that family into three parts (=partition):
- entities with z-index < 0 (background)
- entities with z-index = 0
- entities with z-index > 0 (foreground)

I will use the new `partitionTo` function for that to avoid creating new collections each frame.

In my scenario this should simplify the RenderSystem and also make it faster because I just have one family and one sort call instead of three families with three separate sort calls.