### PR TITLE
Ability to add systems to the world after world creation

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
@@ -80,15 +80,6 @@ data class Family(
     @PublishedApi
     internal val entityService: EntityService = world.entityService,
 ) : EntityComponentContext(world.componentService) {
-    /**
-     * Optional [FamilyHook] that can be defined during world configuration.
-     */
-    internal var ownAddHook: FamilyHook? = null
-
-    /**
-     * Optional [FamilyHook] that can be defined during world configuration.
-     */
-    internal var ownRemoveHook: FamilyHook? = null
 
     /**
      * An optional [FamilyHook] that gets called whenever an [entity][Entity] enters the family.
@@ -232,7 +223,6 @@ data class Family(
             isDirty = true
             if (activeEntities.hasNoValueAtIndex(entity.id)) countEntities++
             activeEntities[entity.id] = entity
-            ownAddHook?.invoke(world, entity)
             addHook?.invoke(world, entity)
         }
     }
@@ -252,7 +242,6 @@ data class Family(
             isDirty = true
             countEntities++
             activeEntities[entity.id] = entity
-            ownAddHook?.invoke(world, entity)
             addHook?.invoke(world, entity)
         } else if (!entityInFamily && currentEntity != null) {
             // existing entity gets removed
@@ -260,7 +249,6 @@ data class Family(
             countEntities--
             activeEntities.removeAt(entity.id)
             removeHook?.invoke(world, entity)
-            ownRemoveHook?.invoke(world, entity)
         }
     }
 
@@ -275,7 +263,6 @@ data class Family(
             activeEntities.removeAt(entity.id)
             countEntities--
             removeHook?.invoke(world, entity)
-            ownRemoveHook?.invoke(world, entity)
         }
     }
 

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
@@ -81,6 +81,16 @@ data class Family(
     internal val entityService: EntityService = world.entityService,
 ) : EntityComponentContext(world.componentService) {
     /**
+     * Optional [FamilyHook] that can be defined during world configuration.
+     */
+    internal var ownAddHook: FamilyHook? = null
+
+    /**
+     * Optional [FamilyHook] that can be defined during world configuration.
+     */
+    internal var ownRemoveHook: FamilyHook? = null
+
+    /**
      * An optional [FamilyHook] that gets called whenever an [entity][Entity] enters the family.
      */
     internal var addHook: FamilyHook? = null
@@ -222,6 +232,7 @@ data class Family(
             isDirty = true
             if (activeEntities.hasNoValueAtIndex(entity.id)) countEntities++
             activeEntities[entity.id] = entity
+            ownAddHook?.invoke(world, entity)
             addHook?.invoke(world, entity)
         }
     }
@@ -241,6 +252,7 @@ data class Family(
             isDirty = true
             countEntities++
             activeEntities[entity.id] = entity
+            ownAddHook?.invoke(world, entity)
             addHook?.invoke(world, entity)
         } else if (!entityInFamily && currentEntity != null) {
             // existing entity gets removed
@@ -248,6 +260,7 @@ data class Family(
             countEntities--
             activeEntities.removeAt(entity.id)
             removeHook?.invoke(world, entity)
+            ownRemoveHook?.invoke(world, entity)
         }
     }
 
@@ -262,6 +275,7 @@ data class Family(
             activeEntities.removeAt(entity.id)
             countEntities--
             removeHook?.invoke(world, entity)
+            ownRemoveHook?.invoke(world, entity)
         }
     }
 

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/family.kt
@@ -80,7 +80,6 @@ data class Family(
     @PublishedApi
     internal val entityService: EntityService = world.entityService,
 ) : EntityComponentContext(world.componentService) {
-
     /**
      * An optional [FamilyHook] that gets called whenever an [entity][Entity] enters the family.
      */

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -160,8 +160,18 @@ abstract class IteratingSystem(
     protected val comparator: EntityComparator = EMPTY_COMPARATOR,
     protected val sortingType: SortingType = Automatic,
     interval: Interval = EachFrame,
-    enabled: Boolean = true
-) : IntervalSystem(interval, enabled) {
+    enabled: Boolean = true,
+    world: World
+) : IntervalSystem(interval, enabled, world) {
+
+    constructor(
+        family: Family,
+        comparator: EntityComparator = EMPTY_COMPARATOR,
+        sortingType: SortingType = Automatic,
+        interval: Interval = EachFrame,
+        enabled: Boolean = true,
+    ) : this(family, comparator, sortingType, interval, enabled, World.CURRENT_WORLD ?: throw FleksWrongConfigurationUsageException())
+
     /**
      * Flag that defines if sorting of [entities][Entity] will be performed the next time [onTick] is called.
      *

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -281,21 +281,28 @@ class World internal constructor(
     /**
      * Adds a new system to the world.
      *
-     * @param system The system to be added to the world. This should be an instance of a class that extends IntervalSystem.
      * @param index The position at which the system should be inserted in the list of systems. If null, the system is added at the end of the list.
      * This parameter is optional and defaults to null.
+     * @param system The system to be added to the world. This should be an instance of a class that extends IntervalSystem.
      *
      * @throws FleksSystemAlreadyAddedException if the system was already added before.
      */
-    fun add(system: IntervalSystem, index: Int? = null) {
+    fun add(index: Int, system: IntervalSystem) {
         if (systems.any { it::class == system::class }) {
             throw FleksSystemAlreadyAddedException(system::class)
         }
 
         setUpAggregatedFamilyHooks(listOf(system))
 
-        mutableSystems.add(index ?: mutableSystems.size, system)
+        mutableSystems.add(index, system)
     }
+
+    /**
+     * Adds a new system to the world.
+     *
+     * @param system The system to be added to the world. This should be an instance of a class that extends IntervalSystem.
+     */
+    fun add(system: IntervalSystem) = add(systems.size, system)
 
     /**
      * Removes the specified system from the world.

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -644,7 +644,8 @@ class World internal constructor(
      */
     fun update(deltaTime: Float) {
         this.deltaTime = deltaTime
-        systems.forEach { system ->
+        for (i in systems.indices) {
+            val system = systems[i]
             if (system.enabled) {
                 system.onUpdate()
             }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -88,10 +88,10 @@ class FamilyConfiguration(
         family: Family,
         hook: FamilyHook
     ) {
-        if (family.addHook != null) {
+        if (family.ownAddHook != null) {
             throw FleksHookAlreadyAddedException("addHook", "Family $family")
         }
-        family.addHook = hook
+        family.ownAddHook = hook
     }
 
     /**
@@ -102,10 +102,10 @@ class FamilyConfiguration(
         family: Family,
         hook: FamilyHook
     ) {
-        if (family.removeHook != null) {
+        if (family.ownRemoveHook != null) {
             throw FleksHookAlreadyAddedException("removeHook", "Family $family")
         }
-        family.removeHook = hook
+        family.ownRemoveHook = hook
     }
 }
 
@@ -663,10 +663,8 @@ class World internal constructor(
             .mapNotNull { if (it is IteratingSystem && it is FamilyOnAdd) it else null }
             .groupBy { it.family }
             .forEach { (family, systemList) ->
-                val ownHook = family.addHook
                 val systemArray = systemList.toTypedArray()
                 family.addHook = { entity ->
-                    ownHook?.invoke(this, entity)
                     systemArray.forEach { it.onAddEntity(entity) }
                 }
             }
@@ -676,11 +674,9 @@ class World internal constructor(
             .mapNotNull { if (it is IteratingSystem && it is FamilyOnRemove) it else null }
             .groupBy { it.family }
             .forEach { (family, systemList) ->
-                val ownHook = family.removeHook
                 val systemArray = systemList.toTypedArray()
                 family.removeHook = { entity ->
                     systemArray.forEachReverse { it.onRemoveEntity(entity) }
-                    ownHook?.invoke(this, entity)
                 }
             }
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -657,7 +657,7 @@ class World internal constructor(
      */
     fun dispose() {
         entityService.removeAll()
-        systems.reversed().forEach { it.onDispose() }
+        systems.forEachReverse { it.onDispose() }
     }
 
     /**

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/FamilySystemHookTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/FamilySystemHookTest.kt
@@ -1,9 +1,7 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.World.Companion.family
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 private class SimpleTestComponent : Component<SimpleTestComponent> {
     companion object : ComponentType<SimpleTestComponent>()
@@ -14,10 +12,12 @@ private class OnAddHookSystem(world: World? = null) : IteratingSystem(
     world = world ?: World.CURRENT_WORLD!!, family = world?.family { all(SimpleTestComponent) } ?: family { all(SimpleTestComponent) }
 ), FamilyOnAdd {
 
-    var addEntityHandled = false
+    val addEntityHandled
+        get() = addEntityHandledCount > 0
+    var addEntityHandledCount = 0
 
     override fun onAddEntity(entity: Entity) {
-        addEntityHandled = true
+        addEntityHandledCount++
     }
 
     override fun onTickEntity(entity: Entity) = Unit
@@ -27,10 +27,12 @@ private class OnRemoveHookSystem(world: World? = null) : IteratingSystem(
     world = world ?: World.CURRENT_WORLD!!, family = world?.family { all(SimpleTestComponent) } ?: family { all(SimpleTestComponent) }
 ), FamilyOnRemove {
 
-    var removeEntityHandled = false
+    val removeEntityHandled
+        get() = removeEntityHandledCount > 0
+    var removeEntityHandledCount = 0
 
     override fun onRemoveEntity(entity: Entity) {
-        removeEntityHandled = true
+        removeEntityHandledCount++
     }
 
     override fun onTickEntity(entity: Entity) = Unit
@@ -67,11 +69,28 @@ internal class FamilySystemHookTest {
         val world = configureWorld {}.also {
             it.add(OnAddHookSystem(world = it))
         }
-
-        world.entity { it += SimpleTestComponent() }
-
         val system = world.system<OnAddHookSystem>()
-        assertTrue { system.addEntityHandled }
+
+        // add an entity after the system is added, should trigger the onAddEntity hook
+        world.entity { it += SimpleTestComponent() }
+        assertEquals(1, system.addEntityHandledCount)
+
+        // remove system, there should be no hooks
+        world -= system
+        assertNull(system.family.addHook)
+
+        // add an entity after the system is removed, should not trigger the onAddEntity hook
+        world.entity { it += SimpleTestComponent() }
+        assertEquals(1, system.addEntityHandledCount)
+
+        // add the system back, existing entities don't trigger the hook
+        world += system
+        assertNotNull(system.family.addHook)
+        assertEquals(1, system.addEntityHandledCount)
+
+        // add an entity after the system is added back, should trigger the onAddEntity hook
+        world.entity { it += SimpleTestComponent() }
+        assertEquals(2, system.addEntityHandledCount)
     }
 
     @Test
@@ -94,12 +113,32 @@ internal class FamilySystemHookTest {
         val world = configureWorld {}.also {
             it.add(OnRemoveHookSystem(world = it))
         }
-
-        val entity = world.entity { it += SimpleTestComponent() }
-        world -= entity
-
         val system = world.system<OnRemoveHookSystem>()
+
+        val entity1 = world.entity { it += SimpleTestComponent() }
+        val entity2 = world.entity { it += SimpleTestComponent() }
+        val entity3 = world.entity { it += SimpleTestComponent() }
+
+        // remove entity after the system is added, should trigger the onRemoveEntity hook
+        world -= entity1
         assertTrue { system.removeEntityHandled }
+
+        // remove system, there should be no hooks
+        world -= system
+        assertNull(system.family.removeHook)
+
+        // remove an entity after the system is removed, should not trigger the onRemoveEntity hook
+        world -= entity2
+        assertEquals(1, system.removeEntityHandledCount)
+
+        // add the system back, existing entities don't trigger the hook
+        world += system
+        assertNotNull(system.family.removeHook)
+        assertEquals(1, system.removeEntityHandledCount)
+
+        // add an entity after the system is added back, should trigger the onAddEntity hook
+        world -= entity3
+        assertEquals(2, system.removeEntityHandledCount)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -1052,7 +1052,7 @@ internal class WorldTest {
             }
         }
         val system = WorldTestIteratingSystem(world = world)
-        world.add(system, 0)
+        world.add(0, system)
 
         assertEquals(system, world.systems[0])
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -491,8 +491,8 @@ internal class WorldTest {
             }
         }
 
-        assertNotNull(testFamily.addHook)
-        assertNotNull(testFamily.removeHook)
+        assertNotNull(testFamily.ownAddHook)
+        assertNotNull(testFamily.ownRemoveHook)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -491,8 +491,8 @@ internal class WorldTest {
             }
         }
 
-        assertNotNull(testFamily.ownAddHook)
-        assertNotNull(testFamily.ownRemoveHook)
+        assertNotNull(testFamily.addHook)
+        assertNotNull(testFamily.removeHook)
     }
 
     @Test

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -36,7 +36,7 @@ private class WorldTestComponent2 : Component<WorldTestComponent2> {
     companion object : ComponentType<WorldTestComponent2>()
 }
 
-private class WorldTestIntervalSystem : IntervalSystem() {
+private class WorldTestIntervalSystem(world: World = World.CURRENT_WORLD!!) : IntervalSystem(world = world) {
     var numCalls = 0
     var disposed = false
 
@@ -50,8 +50,9 @@ private class WorldTestIntervalSystem : IntervalSystem() {
 }
 
 private class WorldTestIteratingSystem(
-    val testInject: String = inject()
-) : IteratingSystem(family { all(WorldTestComponent) }) {
+    world: World = World.CURRENT_WORLD!!,
+    val testInject: String = world.inject()
+) : IteratingSystem(world = world, family = world.family { all(WorldTestComponent) }) {
     var numCalls = 0
     var numCallsEntity = 0
 
@@ -1025,5 +1026,71 @@ internal class WorldTest {
             }
             assertEquals(1, numAdd)
         }
+    }
+
+    @Test
+    fun addingASystemAfterWorldConfiguration() {
+        val world = configureWorld {
+            injectables {
+                add("42")
+            }
+        }
+        world.add(WorldTestIteratingSystem(world = world))
+
+        assertNotNull(world.system<WorldTestIteratingSystem>())
+    }
+
+    @Test
+    fun addingASystemAtIndexAfterWorldConfiguration() {
+        val world = configureWorld {
+            injectables {
+                add("42")
+            }
+
+            systems {
+                add(WorldTestIntervalSystem())
+            }
+        }
+        val system = WorldTestIteratingSystem(world = world)
+        world.add(system, 0)
+
+        assertEquals(system, world.systems[0])
+    }
+
+    @Test
+    fun addingASystemPlusAssignAfterWorldConfiguration() {
+        val world = configureWorld {
+            injectables {
+                add("42")
+            }
+        }
+        world += WorldTestIteratingSystem(world = world)
+
+        assertNotNull(world.system<WorldTestIteratingSystem>())
+    }
+
+    @Test
+    fun removingASystemAfterWorldConfiguration() {
+        val world = configureWorld {
+            injectables {
+                add("42")
+            }
+        }
+
+        // add 2 systems
+        val system1 = WorldTestIteratingSystem(world = world)
+        val system2 = WorldTestIntervalSystem(world = world)
+        world.add(system1)
+        world.add(system2)
+        assertEquals(2, world.systems.size)
+
+        // remove using remove function
+        world.remove(system2)
+        assertEquals(1, world.systems.size)
+        assertEquals(system1, world.systems[0])
+
+        // remove using minusAssign operator
+        world -= system1
+        assertEquals(0, world.systems.size)
     }
 }


### PR DESCRIPTION
I changed world.system to return a List instead on an Array, so while it didn't impact any tests, I guess its possible some users are expecting an Array?

I ran the benchmarks before and after changes and results are basically identical.

I added a constructor to IntervalSystem (to match old signature), as it was breaking some js/wasm tests otherwise.

Please review and give feedback.