### PR TITLE
Be more Kotlin-y and also work with durations.

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -5,6 +5,7 @@ import com.github.quillraven.fleks.collection.MutableEntityBag
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import kotlin.native.concurrent.ThreadLocal
+import kotlin.time.Duration
 
 /**
  * Snapshot for an [entity][Entity] that contains its [components][Component] and [tags][EntityTag].
@@ -446,6 +447,14 @@ class World internal constructor(
                 system.onUpdate()
             }
         }
+    }
+
+    /**
+     * Updates all [enabled][IntervalSystem.enabled] [systems][IntervalSystem] of the world
+     * using the given [deltaTime].
+     */
+    fun update(deltaTime: Duration) {
+        update(deltaTime.inWholeNanoseconds / 1_000_000_000f)
     }
 
     /**

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import kotlin.native.concurrent.ThreadLocal
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 /**
  * Snapshot for an [entity][Entity] that contains its [components][Component] and [tags][EntityTag].
@@ -454,7 +455,7 @@ class World internal constructor(
      * using the given [deltaTime].
      */
     fun update(deltaTime: Duration) {
-        update(deltaTime.inWholeNanoseconds / 1_000_000_000f)
+        update(deltaTime.toDouble(DurationUnit.MILLISECONDS).toFloat())
     }
 
     /**

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -5,6 +5,7 @@ import com.github.quillraven.fleks.World.Companion.inject
 import com.github.quillraven.fleks.collection.compareEntity
 import com.github.quillraven.fleks.collection.compareEntityBy
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 
 private data class WorldTestComponent(
     var x: Float = 0f,
@@ -310,6 +311,27 @@ internal class WorldTest {
         w.system<WorldTestIteratingSystem>().enabled = false
 
         w.update(1f)
+
+        assertEquals(1f, w.deltaTime)
+        assertEquals(1, w.system<WorldTestIntervalSystem>().numCalls)
+        assertEquals(0, w.system<WorldTestIteratingSystem>().numCalls)
+    }
+
+    @Test
+    fun updateWorldWithDurationOf1() {
+        val w = configureWorld {
+            injectables {
+                add("42")
+            }
+
+            systems {
+                add(WorldTestIntervalSystem())
+                add(WorldTestIteratingSystem())
+            }
+        }
+        w.system<WorldTestIteratingSystem>().enabled = false
+
+        w.update(1.milliseconds)
 
         assertEquals(1f, w.deltaTime)
         assertEquals(1, w.system<WorldTestIntervalSystem>().numCalls)


### PR DESCRIPTION
I was going though my code and removing System timing functions and using the kotlin.time functions instead. 
Though it would be nice for Fleks to support the kotlin.time.Duration value type. 