### PR TITLE
change (add system) parameter to generic type for flexibility

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/worldCfg.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/worldCfg.kt
@@ -57,7 +57,7 @@ class SystemConfiguration(
      *
      * @throws [FleksSystemAlreadyAddedException] if the system was already added before.
      */
-    fun add(system: IntervalSystem) {
+    fun <T: IntervalSystem> add(system: T) {
         if (systems.any { it::class == system::class }) {
             throw FleksSystemAlreadyAddedException(system::class)
         }


### PR DESCRIPTION
My use case:

```
            systems {
                core.systems.forEach { add(it) }
                game.systems.forEach { add(it) }
            }
```

While iterating system list we need generic type or else `add` function always infers `IntervalSystem`.