### PR TITLE
use Duration instead of Float

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -1,6 +1,7 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.EntityComparator
+import kotlin.time.Duration
 
 /**
  * An interval for an [IntervalSystem]. There are two kinds of intervals:
@@ -16,7 +17,7 @@ data object EachFrame : Interval
 /**
  * @param step the time in seconds when an [IntervalSystem] gets updated.
  */
-data class Fixed(val step: Float) : Interval
+data class Fixed(val step: Duration) : Interval
 
 /**
  * A basic system of a [world][World] without a context to [entities][Entity].
@@ -51,7 +52,7 @@ abstract class IntervalSystem(
             }
         }
 
-    private var accumulator: Float = 0.0f
+    private var accumulator: Duration = Duration.ZERO
 
     /**
      * Returns the time in seconds since the last time [onUpdate] was called.
@@ -60,7 +61,7 @@ abstract class IntervalSystem(
      *
      * Otherwise, the [step][Fixed.step] value is returned.
      */
-    val deltaTime: Float
+    val deltaTime: Duration
         get() = if (interval is Fixed) interval.step else world.deltaTime
 
     /**
@@ -98,7 +99,7 @@ abstract class IntervalSystem(
                     accumulator -= stepRate
                 }
 
-                onAlpha(accumulator / stepRate)
+                onAlpha((accumulator / stepRate).toFloat())
             }
         }
     }

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -41,7 +41,7 @@ class World internal constructor(
      * Returns the time passed to [update][World.update].
      * It represents the time in seconds between two frames.
      */
-    var deltaTime = 0f
+    var deltaTime = Duration.ZERO
         private set
 
     @PublishedApi
@@ -441,7 +441,7 @@ class World internal constructor(
      * Updates all [enabled][IntervalSystem.enabled] [systems][IntervalSystem] of the world
      * using the given [deltaTime] in seconds.
      */
-    fun update(deltaTime: Float) {
+    fun update(deltaTime: Duration) {
         this.deltaTime = deltaTime
         for (i in systems.indices) {
             val system = systems[i]
@@ -449,14 +449,6 @@ class World internal constructor(
                 system.onUpdate()
             }
         }
-    }
-
-    /**
-     * Updates all [enabled][IntervalSystem.enabled] [systems][IntervalSystem] of the world
-     * using the given [duration]. The duration is converted to seconds.
-     */
-    fun update(duration: Duration) {
-        update(duration.inWholeNanoseconds * 0.000000001f)
     }
 
     /**

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -1,10 +1,12 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.World.Companion.family
-import kotlin.test.*
-import kotlin.time.Duration
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 data object Visible : EntityTag()
 
@@ -53,12 +55,12 @@ class EntityTagTest {
             it += TestTags.PLAYER
         }
 
-        world.update(1000.toDuration(DurationUnit.SECONDS))
+        world.update(1.seconds)
         assertEquals(1, testSystem.ticks)
 
         testSystem.ticks = 0
         with(world) { entity.configure { it -= Visible } }
-        world.update(1000.toDuration(DurationUnit.SECONDS))
+        world.update(1.seconds)
         assertEquals(0, testSystem.ticks)
     }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/EntityTagTest.kt
@@ -2,6 +2,9 @@ package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.World.Companion.family
 import kotlin.test.*
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 data object Visible : EntityTag()
 
@@ -50,12 +53,12 @@ class EntityTagTest {
             it += TestTags.PLAYER
         }
 
-        world.update(1f)
+        world.update(1000.toDuration(DurationUnit.SECONDS))
         assertEquals(1, testSystem.ticks)
 
         testSystem.ticks = 0
         with(world) { entity.configure { it -= Visible } }
-        world.update(1f)
+        world.update(1000.toDuration(DurationUnit.SECONDS))
         assertEquals(0, testSystem.ticks)
     }
 

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
@@ -5,6 +5,8 @@ import com.github.quillraven.fleks.Sprite.Companion.SpriteForeground
 import com.github.quillraven.fleks.World.Companion.family
 import com.github.quillraven.fleks.World.Companion.inject
 import kotlin.test.*
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 private data class Position(
     var x: Float,
@@ -159,7 +161,7 @@ class Fleks2TDD {
             it += Position(0f, 0f)
         }
 
-        world.update(1f)
+        world.update(1000.toDuration(DurationUnit.SECONDS))
 
         assertEquals(1f, with(world) { entity[Position] }.x)
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/Fleks2TDD.kt
@@ -4,9 +4,14 @@ import com.github.quillraven.fleks.Sprite.Companion.SpriteBackground
 import com.github.quillraven.fleks.Sprite.Companion.SpriteForeground
 import com.github.quillraven.fleks.World.Companion.family
 import com.github.quillraven.fleks.World.Companion.inject
-import kotlin.test.*
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 private data class Position(
     var x: Float,
@@ -161,7 +166,7 @@ class Fleks2TDD {
             it += Position(0f, 0f)
         }
 
-        world.update(1000.toDuration(DurationUnit.SECONDS))
+        world.update(1.seconds)
 
         assertEquals(1f, with(world) { entity[Position] }.x)
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/SystemOrderTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/SystemOrderTest.kt
@@ -3,6 +3,7 @@ package com.github.quillraven.fleks
 import com.github.quillraven.fleks.World.Companion.family
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration
 
 private class TestComponent : Component<TestComponent> {
     companion object : ComponentType<TestComponent>()
@@ -94,7 +95,7 @@ internal class SystemOrderTest {
             }
         }
 
-        world.update(0f)
+        world.update(Duration.ZERO)
 
         assertEquals(FirstSystem::class, systemOrder[0]::class)
         assertEquals(SecondSystem::class, systemOrder[1]::class)
@@ -146,7 +147,7 @@ internal class SystemOrderTest {
         }
 
         world.entity { it += TestComponent() }
-        world.update(0f)
+        world.update(Duration.ZERO)
 
         assertEquals(FirstSystem::class, systemOrder[0]::class)
         assertEquals(SecondSystem::class, systemOrder[1]::class)

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
@@ -5,6 +5,9 @@ import com.github.quillraven.fleks.World.Companion.inject
 import com.github.quillraven.fleks.collection.compareEntity
 import com.github.quillraven.fleks.collection.compareEntityBy
 import kotlin.test.*
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 private class SystemTestIntervalSystemEachFrame : IntervalSystem(
     interval = EachFrame
@@ -27,7 +30,7 @@ private class SystemTestIntervalSystemEachFrame : IntervalSystem(
 }
 
 private class SystemTestIntervalSystemFixed : IntervalSystem(
-    interval = Fixed(0.25f)
+    interval = Fixed(250.toDuration(DurationUnit.MILLISECONDS))
 ) {
     var numCalls = 0
     var lastAlpha = 0f
@@ -55,7 +58,7 @@ private data class SystemTestComponent(
 
 private class SystemTestIteratingSystem : IteratingSystem(
     family = family { all(SystemTestComponent) },
-    interval = Fixed(0.25f)
+    interval = Fixed(250.toDuration(DurationUnit.MILLISECONDS))
 ) {
     var numEntityCalls = 0
     var numAlphaCalls = 0
@@ -111,7 +114,7 @@ private class SystemTestIteratingSystemSortAutomatic : IteratingSystem(
 
 private class SystemTestFixedSystemRemoval : IteratingSystem(
     family = family { all(SystemTestComponent) },
-    interval = Fixed(1f)
+    interval = Fixed(1.toDuration(DurationUnit.SECONDS))
 ) {
     var numEntityCalls = 0
     var lastEntityProcess = Entity.NONE
@@ -210,9 +213,9 @@ internal class SystemTest {
             }
         }
         val system = w.system<SystemTestIntervalSystemEachFrame>()
-        w.update(42f)
+        w.update(42.toDuration(DurationUnit.SECONDS))
 
-        assertEquals(42f, system.deltaTime)
+        assertEquals(42L, system.deltaTime.inWholeSeconds)
     }
 
     @Test
@@ -224,7 +227,7 @@ internal class SystemTest {
         }
         val system = w.system<SystemTestIntervalSystemFixed>()
 
-        system.world.update(1.1f)
+        system.world.update(1100.toDuration(DurationUnit.MILLISECONDS))
 
         assertEquals(4, system.numCalls)
         assertEquals(0.1f / 0.25f, system.lastAlpha, 0.0001f)
@@ -239,7 +242,7 @@ internal class SystemTest {
         }
         val system = w.system<SystemTestIntervalSystemFixed>()
 
-        assertEquals(0.25f, system.deltaTime, 0.0001f)
+        assertEquals(250.toDuration(DurationUnit.MILLISECONDS), system.deltaTime)
     }
 
     @Test
@@ -303,7 +306,7 @@ internal class SystemTest {
         world.entity { it += SystemTestComponent() }
         world.entity { it += SystemTestComponent() }
 
-        world.update(0.3f)
+        world.update(300.toDuration(DurationUnit.MILLISECONDS))
 
         val system = world.system<SystemTestIteratingSystem>()
         assertEquals(2, system.numEntityCalls)
@@ -322,7 +325,7 @@ internal class SystemTest {
         val system = world.system<SystemTestIteratingSystem>()
         system.entityToConfigure = entity
 
-        world.update(0.3f)
+        world.update(300.toDuration(DurationUnit.MILLISECONDS))
 
         assertFalse(with(world) { entity has SystemTestComponent })
     }
@@ -338,7 +341,7 @@ internal class SystemTest {
         world.entity { it += SystemTestComponent(x = 10f) }
         val expectedEntity = world.entity { it += SystemTestComponent(x = 5f) }
 
-        world.update(0f)
+        world.update(Duration.ZERO)
 
         assertEquals(expectedEntity, world.system<SystemTestIteratingSystemSortAutomatic>().lastEntityProcess)
     }
@@ -356,7 +359,7 @@ internal class SystemTest {
         val system = world.system<SystemTestIteratingSystemSortManual>()
 
         system.doSort = true
-        world.update(0f)
+        world.update(Duration.ZERO)
 
         assertEquals(expectedEntity, system.lastEntityProcess)
         assertFalse(system.doSort)
@@ -385,7 +388,7 @@ internal class SystemTest {
         val system = world.system<SystemTestIntervalSystemEachFrame>()
         system.enabled = false
 
-        world.update(0f)
+        world.update(Duration.ZERO)
 
         assertEquals(0, system.numCalls)
     }
@@ -405,8 +408,8 @@ internal class SystemTest {
 
         // call it twice - first call still iterates over all three entities
         // while the second call will only iterate over the remaining two entities
-        world.update(0f)
-        world.update(0f)
+        world.update(Duration.ZERO)
+        world.update(Duration.ZERO)
 
         assertEquals(5, system.numEntityCalls)
     }
@@ -427,8 +430,8 @@ internal class SystemTest {
 
         // call it twice - first call still iterates over all three entities
         // while the second call will only iterate over the remaining two entities
-        world.update(1f)
-        world.update(1f)
+        world.update(1.toDuration(DurationUnit.SECONDS))
+        world.update(1.toDuration(DurationUnit.SECONDS))
 
         assertEquals(4, system.numEntityCalls)
     }
@@ -467,7 +470,7 @@ internal class SystemTest {
             }
         }
 
-        world.update(0f)
+        world.update(Duration.ZERO)
 
         val system = world.system<SystemTestEntityCreation>()
         assertEquals(1, system.numTicks)

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/SystemTest.kt
@@ -4,10 +4,16 @@ import com.github.quillraven.fleks.World.Companion.family
 import com.github.quillraven.fleks.World.Companion.inject
 import com.github.quillraven.fleks.collection.compareEntity
 import com.github.quillraven.fleks.collection.compareEntityBy
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 private class SystemTestIntervalSystemEachFrame : IntervalSystem(
     interval = EachFrame
@@ -30,7 +36,7 @@ private class SystemTestIntervalSystemEachFrame : IntervalSystem(
 }
 
 private class SystemTestIntervalSystemFixed : IntervalSystem(
-    interval = Fixed(250.toDuration(DurationUnit.MILLISECONDS))
+    interval = Fixed(250.milliseconds)
 ) {
     var numCalls = 0
     var lastAlpha = 0f
@@ -58,7 +64,7 @@ private data class SystemTestComponent(
 
 private class SystemTestIteratingSystem : IteratingSystem(
     family = family { all(SystemTestComponent) },
-    interval = Fixed(250.toDuration(DurationUnit.MILLISECONDS))
+    interval = Fixed(250.milliseconds)
 ) {
     var numEntityCalls = 0
     var numAlphaCalls = 0
@@ -114,7 +120,7 @@ private class SystemTestIteratingSystemSortAutomatic : IteratingSystem(
 
 private class SystemTestFixedSystemRemoval : IteratingSystem(
     family = family { all(SystemTestComponent) },
-    interval = Fixed(1.toDuration(DurationUnit.SECONDS))
+    interval = Fixed(1.seconds)
 ) {
     var numEntityCalls = 0
     var lastEntityProcess = Entity.NONE
@@ -213,7 +219,7 @@ internal class SystemTest {
             }
         }
         val system = w.system<SystemTestIntervalSystemEachFrame>()
-        w.update(42.toDuration(DurationUnit.SECONDS))
+        w.update(42.seconds)
 
         assertEquals(42L, system.deltaTime.inWholeSeconds)
     }
@@ -227,7 +233,7 @@ internal class SystemTest {
         }
         val system = w.system<SystemTestIntervalSystemFixed>()
 
-        system.world.update(1100.toDuration(DurationUnit.MILLISECONDS))
+        system.world.update(1100.milliseconds)
 
         assertEquals(4, system.numCalls)
         assertEquals(0.1f / 0.25f, system.lastAlpha, 0.0001f)
@@ -242,7 +248,7 @@ internal class SystemTest {
         }
         val system = w.system<SystemTestIntervalSystemFixed>()
 
-        assertEquals(250.toDuration(DurationUnit.MILLISECONDS), system.deltaTime)
+        assertEquals(250.milliseconds, system.deltaTime)
     }
 
     @Test
@@ -306,7 +312,7 @@ internal class SystemTest {
         world.entity { it += SystemTestComponent() }
         world.entity { it += SystemTestComponent() }
 
-        world.update(300.toDuration(DurationUnit.MILLISECONDS))
+        world.update(300.milliseconds)
 
         val system = world.system<SystemTestIteratingSystem>()
         assertEquals(2, system.numEntityCalls)
@@ -325,7 +331,7 @@ internal class SystemTest {
         val system = world.system<SystemTestIteratingSystem>()
         system.entityToConfigure = entity
 
-        world.update(300.toDuration(DurationUnit.MILLISECONDS))
+        world.update(300.milliseconds)
 
         assertFalse(with(world) { entity has SystemTestComponent })
     }
@@ -430,8 +436,8 @@ internal class SystemTest {
 
         // call it twice - first call still iterates over all three entities
         // while the second call will only iterate over the remaining two entities
-        world.update(1.toDuration(DurationUnit.SECONDS))
-        world.update(1.toDuration(DurationUnit.SECONDS))
+        world.update(1.seconds)
+        world.update(1.seconds)
 
         assertEquals(4, system.numEntityCalls)
     }

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -5,8 +5,11 @@ import com.github.quillraven.fleks.World.Companion.inject
 import com.github.quillraven.fleks.collection.compareEntity
 import com.github.quillraven.fleks.collection.compareEntityBy
 import kotlin.test.*
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 private data class WorldTestComponent(
     var x: Float = 0f,
@@ -311,9 +314,9 @@ internal class WorldTest {
         }
         w.system<WorldTestIteratingSystem>().enabled = false
 
-        w.update(1f)
+        w.update(1.toDuration(DurationUnit.SECONDS))
 
-        assertEquals(1f, w.deltaTime)
+        assertEquals(1L, w.deltaTime.inWholeSeconds)
         assertEquals(1, w.system<WorldTestIntervalSystem>().numCalls)
         assertEquals(0, w.system<WorldTestIteratingSystem>().numCalls)
     }
@@ -334,7 +337,7 @@ internal class WorldTest {
 
         w.update(1.seconds)
 
-        assertEquals(1f, w.deltaTime)
+        assertEquals(1L, w.deltaTime.inWholeSeconds)
         assertEquals(1, w.system<WorldTestIntervalSystem>().numCalls)
         assertEquals(0, w.system<WorldTestIteratingSystem>().numCalls)
     }
@@ -343,14 +346,14 @@ internal class WorldTest {
     fun verifyUpdateAndUpdateDurationIsSame() {
         val world = configureWorld { }
 
-        world.update(0.5f)
-        assertEquals(0.5f, world.deltaTime)
+        world.update(500.toDuration(DurationUnit.MILLISECONDS))
+        assertEquals(500, world.deltaTime.inWholeMilliseconds)
 
         world.update(0.5.seconds)
-        assertEquals(0.5f, world.deltaTime)
+        assertEquals(500, world.deltaTime.inWholeMilliseconds)
 
         world.update(500.milliseconds)
-        assertEquals(0.5f, world.deltaTime)
+        assertEquals(500, world.deltaTime.inWholeMilliseconds)
     }
 
     @Test
@@ -459,7 +462,7 @@ internal class WorldTest {
         val e = w.entity()
 
         with(w) { e.configure { it += WorldTestComponent() } }
-        w.update(0f)
+        w.update(Duration.ZERO)
 
         assertEquals(1, w.system<WorldTestIteratingSystem>().numCallsEntity)
     }
@@ -786,7 +789,7 @@ internal class WorldTest {
 
         w.loadSnapshot(snapshot)
         val actual = w.snapshot()
-        w.update(1f)
+        w.update(1.toDuration(DurationUnit.SECONDS))
 
         // 3 entities should be loaded
         assertEquals(3, w.numEntities)

--- a/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
+++ b/src/commonTest/kotlin/com/github/quillraven/fleks/WorldTest.kt
@@ -4,12 +4,17 @@ import com.github.quillraven.fleks.World.Companion.family
 import com.github.quillraven.fleks.World.Companion.inject
 import com.github.quillraven.fleks.collection.compareEntity
 import com.github.quillraven.fleks.collection.compareEntityBy
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 private data class WorldTestComponent(
     var x: Float = 0f,
@@ -314,7 +319,7 @@ internal class WorldTest {
         }
         w.system<WorldTestIteratingSystem>().enabled = false
 
-        w.update(1.toDuration(DurationUnit.SECONDS))
+        w.update(1.seconds)
 
         assertEquals(1L, w.deltaTime.inWholeSeconds)
         assertEquals(1, w.system<WorldTestIntervalSystem>().numCalls)
@@ -346,7 +351,7 @@ internal class WorldTest {
     fun verifyUpdateAndUpdateDurationIsSame() {
         val world = configureWorld { }
 
-        world.update(500.toDuration(DurationUnit.MILLISECONDS))
+        world.update(500.milliseconds)
         assertEquals(500, world.deltaTime.inWholeMilliseconds)
 
         world.update(0.5.seconds)
@@ -789,7 +794,7 @@ internal class WorldTest {
 
         w.loadSnapshot(snapshot)
         val actual = w.snapshot()
-        w.update(1.toDuration(DurationUnit.SECONDS))
+        w.update(1.seconds)
 
         // 3 entities should be loaded
         assertEquals(3, w.numEntities)

--- a/src/jvmBenchmarks/kotlin/com/github/quillraven/fleks/benchmark/fleks.kt
+++ b/src/jvmBenchmarks/kotlin/com/github/quillraven/fleks/benchmark/fleks.kt
@@ -4,6 +4,7 @@ import com.github.quillraven.fleks.*
 import com.github.quillraven.fleks.World.Companion.family
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -127,14 +128,16 @@ open class FleksBenchmark {
     @Benchmark
     fun simple(state: FleksStateSimple) {
         repeat(WORLD_UPDATES) {
-            state.world.update(1L.toDuration(DurationUnit.SECONDS))
+            state.world.update(ONE_SECOND)
         }
     }
 
     @Benchmark
     fun complex(state: FleksStateComplex) {
         repeat(WORLD_UPDATES) {
-            state.world.update(1L.toDuration(DurationUnit.SECONDS))
+            state.world.update(ONE_SECOND)
         }
     }
 }
+
+val ONE_SECOND = 1.toDuration(DurationUnit.SECONDS)

--- a/src/jvmBenchmarks/kotlin/com/github/quillraven/fleks/benchmark/fleks.kt
+++ b/src/jvmBenchmarks/kotlin/com/github/quillraven/fleks/benchmark/fleks.kt
@@ -4,6 +4,8 @@ import com.github.quillraven.fleks.*
 import com.github.quillraven.fleks.World.Companion.family
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 data class FleksPosition(var x: Float = 0f, var y: Float = 0f) : Component<FleksPosition> {
     override fun type() = FleksPosition
@@ -125,14 +127,14 @@ open class FleksBenchmark {
     @Benchmark
     fun simple(state: FleksStateSimple) {
         repeat(WORLD_UPDATES) {
-            state.world.update(1f)
+            state.world.update(1L.toDuration(DurationUnit.SECONDS))
         }
     }
 
     @Benchmark
     fun complex(state: FleksStateComplex) {
         repeat(WORLD_UPDATES) {
-            state.world.update(1f)
+            state.world.update(1L.toDuration(DurationUnit.SECONDS))
         }
     }
 }

--- a/src/jvmBenchmarks/kotlin/com/github/quillraven/fleks/benchmark/fleks.kt
+++ b/src/jvmBenchmarks/kotlin/com/github/quillraven/fleks/benchmark/fleks.kt
@@ -1,12 +1,22 @@
 package com.github.quillraven.fleks.benchmark
 
-import com.github.quillraven.fleks.*
+import com.github.quillraven.fleks.Component
+import com.github.quillraven.fleks.ComponentType
+import com.github.quillraven.fleks.Entity
+import com.github.quillraven.fleks.IteratingSystem
+import com.github.quillraven.fleks.World
 import com.github.quillraven.fleks.World.Companion.family
-import org.openjdk.jmh.annotations.*
+import com.github.quillraven.fleks.configureWorld
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import kotlin.time.Duration.Companion.seconds
 
 data class FleksPosition(var x: Float = 0f, var y: Float = 0f) : Component<FleksPosition> {
     override fun type() = FleksPosition
@@ -128,16 +138,15 @@ open class FleksBenchmark {
     @Benchmark
     fun simple(state: FleksStateSimple) {
         repeat(WORLD_UPDATES) {
-            state.world.update(ONE_SECOND)
+            state.world.update(1.seconds)
         }
     }
 
     @Benchmark
     fun complex(state: FleksStateComplex) {
         repeat(WORLD_UPDATES) {
-            state.world.update(ONE_SECOND)
+            state.world.update(1.seconds)
         }
     }
 }
 
-val ONE_SECOND = 1.toDuration(DurationUnit.SECONDS)


### PR DESCRIPTION
Related to http://github.com/Quillraven/Fleks/discussions/170

Using **Duration** in over **Float** enhances type safety, readability, and unit clarity. It offers built-in functions, and precision reducing errors.