### PR TITLE
proposal for #170 (Duration support)

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -1,6 +1,7 @@
 package com.github.quillraven.fleks
 
 import com.github.quillraven.fleks.collection.EntityComparator
+import kotlin.time.Duration
 
 /**
  * An interval for an [IntervalSystem]. There are two kinds of intervals:
@@ -62,6 +63,12 @@ abstract class IntervalSystem(
      */
     val deltaTime: Float
         get() = if (interval is Fixed) interval.step else world.deltaTime
+
+    /**
+     * Returns the duration since the last time [onUpdate] was called (refer to [World.duration]).
+     */
+    val duration: Duration
+        get() = world.duration
 
     /**
      * This function gets called when the [world configuration][WorldConfiguration.configure] is completed.

--- a/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -44,6 +44,12 @@ class World internal constructor(
     var deltaTime = 0f
         private set
 
+    /**
+     * Returns the duration passed to [update][World.update].
+     */
+    var duration = Duration.ZERO
+        private set
+
     @PublishedApi
     internal val entityService = EntityService(this, entityCapacity)
 
@@ -456,6 +462,7 @@ class World internal constructor(
      * using the given [duration]. The duration is converted to seconds.
      */
     fun update(duration: Duration) {
+        this.duration = duration
         update(duration.inWholeNanoseconds * 0.000000001f)
     }
 


### PR DESCRIPTION
@ygdrasil-io: does something simple like that help you for now? It is not finished yet, more like a WIP. The idea is to simply add a `Duration` field to the world that can be accessed by systems. That way we don't break any existing code but you still have the possibility to use the duration object instead of a float.