### PR TITLE
Update EMPTY_COMPARATOR visibility to public

### DIFF
--- a/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -231,7 +231,7 @@ abstract class IteratingSystem(
     open fun onAlphaEntity(entity: Entity, alpha: Float) = Unit
 
     companion object {
-        private val EMPTY_COMPARATOR = EntityComparator { _, _ -> 0 }
+        val EMPTY_COMPARATOR = EntityComparator { _, _ -> 0 }
     }
 }
 


### PR DESCRIPTION
I am creating my own abstraction off of `IteratingSystem` like so:

```